### PR TITLE
[#3]@JsonCreator / @Valid 테스트케이스 추가

### DIFF
--- a/sql/data.sql
+++ b/sql/data.sql
@@ -1,54 +1,65 @@
+-- 회원
 DROP TABLE IF EXISTS `member`;
 CREATE TABLE `member` (
-                          `member_sid`	bigint	NOT NULL AUTO_INCREMENT PRIMARY KEY	COMMENT '회원SID',
-                          `id`	        varchar(50)	 NOT NULL	COMMENT '회원 아이디',
-                          `role`	        char(1)	NULL	DEFAULT '2'	COMMENT '권한(1:관리자/2:일반)',
-                          `password`	    varchar(100)	NOT NULL,
-                          `email`     	varchar(100)	NULL	COMMENT '이메일 주소',
-                          `hp_no`	        varchar(100)	NULL	COMMENT '핸드폰 번호',
-                          `created_dt`	timestamp	NULL	DEFAULT NOW()	COMMENT '회원 생성일시',
-                          `updated_dt`	timestamp	NULL	COMMENT '회원 수정일시',
-                          `use_yn`	    char(1)	NULL	DEFAULT 'Y'	COMMENT '회원 삭제 구분'
+    `member_id`         bigint	      NOT NULL AUTO_INCREMENT PRIMARY KEY	COMMENT '회원 id pk',
+    `id`	            varchar(50)	  NOT NULL	COMMENT '회원 아이디',
+    `role`	            char(1)	      NULL	DEFAULT '2'	COMMENT '권한(1:관리자/2:일반)',
+    `password`	        varchar(100)  NOT NULL,
+    `email`     	    varchar(100)  NULL	COMMENT '이메일 주소',
+    `hp_no`	            varchar(100)  NULL	COMMENT '핸드폰 번호',
+    `created_dt`	    timestamp	  NULL	DEFAULT NOW()	COMMENT '회원 생성일시',
+    `updated_dt`	    timestamp	  NULL	COMMENT '회원 수정일시',
+    `use_yn`	        char(1)	      NULL DEFAULT 'Y'	COMMENT '회원 삭제 구분'
 );
 
+-- 공연
 DROP TABLE IF EXISTS `performance`;
 CREATE TABLE `performance` (
-                               `performance_sid`	    bigint	NOT NULL AUTO_INCREMENT PRIMARY KEY	COMMENT '공연SID',
-                               `genre`	                char(1)	NULL	COMMENT '공연 장르 구분 값',
-                               `name`	                varchar(500)	NULL	COMMENT '공연 이름',
-                               `place`	                bigint	NULL	DEFAULT NOW(),
-                               `performance_start_dt`	timestamp	NOT NULL COMMENT '공연 시작 일시',
-                               `performance_end_dt`	timestamp	NOT NULL COMMENT '공연 종료 일시',
-                               `reserve_start_dt`	    timestamp	NOT NULL	COMMENT '예매시작시간',
-                               `reserve_end_dt`	    timestamp	NOT NULL	COMMENT '예매종료시간',
-                               `created_at`	        bigint	NULL	DEFAULT NOW()	COMMENT '공연정보 생성일시',
-                               `read_count`	        int	DEFAULT 0	COMMENT '공연 상세 화면 조회 수',
-                               `performer_sid`     	bigint	NOT NULL	COMMENT '회원key'
+    `performance_id`    bigint	      NOT NULL AUTO_INCREMENT PRIMARY KEY	COMMENT '공연 ID',
+    `genre`	            char(1)	      NULL	COMMENT '공연 장르 구분 값',
+    `name`	            varchar(500)  NULL	COMMENT '공연 이름',
+    `place`	            varchar(500)  NULL    COMMENT '공연 장소',
+    `start_dt`	        timestamp	  NOT NULL    COMMENT '공연 시작 일시',
+    `end_dt`	        timestamp	  NOT NULL    COMMENT '공연 종료 일시',
+    `created_at`	    timestamp	  NULL	DEFAULT NOW()	COMMENT '공연정보 생성일시',
+    `performer_id`     	bigint	      NOT NULL	COMMENT '공연자 ID'
 );
 
+-- 공연자
 DROP TABLE IF EXISTS `performer`;
 CREATE TABLE `performer` (
-                             `performer_sid`	bigint	NOT NULL	COMMENT '공연SID',
-                             `name`	varchar(300)	NOT NULL	    COMMENT '공연자명'
+    `performer_id`	    bigint	      NOT NULL	COMMENT '공연자 ID',
+    `name`	            varchar(300)  NOT NULL	COMMENT '공연자명'
 );
 
+-- 티켓 정보
 DROP TABLE IF EXISTS `ticket`;
 CREATE TABLE `ticket` (
-                          `ticket_sid`	    bigint	    NOT NULL AUTO_INCREMENT PRIMARY KEY	COMMENT '티켓SID',
-                          `ticket_no`			int	    	NOT NULL	COMMENT '티켓번호',
-                          `ticket_date`	    timestamp	NOT NULL	COMMENT '예매한 공연일자',
-                          `grade`	            char(1)	    NOT NULL	COMMENT '예매한 좌석 등급',
-                          `price`	            bigint	    NULL        COMMENT '티켓 가격',
-                          `created_dt`	    bigint	    NULL	    COMMENT '티켓 생성일시',
-                          `reservation_sid`	bigint	    NOT NULL	COMMENT '예매SID',
-                          `performance_sid`	bigint	    NOT NULL	COMMENT '공연SID'
+    `ticket_id`	        bigint	      NOT NULL AUTO_INCREMENT PRIMARY KEY	COMMENT '티켓 ID',
+    `start_dt`	        timestamp	  NOT NULL	COMMENT '티켓 예매시작시간',
+    `end_dt`	        timestamp	  NOT NULL	COMMENT '티켓 예매종료시간',
+    `created_dt`	    timestamp     NULL DEFAULT NOW() COMMENT '티켓 생성일시',
+    `performance_id`	bigint	      NOT NULL	COMMENT '공연 ID'
 );
 
-DROP TABLE IF EXISTS `reservation`;
-CREATE TABLE `reservation` (
-                               `reservation_sid`	bigint	    NOT NULL AUTO_INCREMENT PRIMARY KEY	COMMENT '예매SID',
-                               `status`	        char(1)	    NOT NULL	COMMENT '예매상태(S:결제완료/C:결제취소)',
-                               `created_dt`	    timestamp	NOT NULL	DEFAULT NOW()	COMMENT '예매 생성일시',
-                               `updated_dt`	    timestamp	NULL	    DEFAULT NOW()	COMMENT '예매수정일시',
-                               `member_sid`	    bigint	    NOT NULL	COMMENT '회원SID'
+-- 티켓 등급
+DROP TABLE IF EXISTS `ticket_grade`;
+CREATE TABLE `ticket_grade` (
+    `ticket_grade_id`   bigint	      NOT NULL AUTO_INCREMENT PRIMARY KEY	COMMENT '티켓 등급 ID',
+    `grade`	            timestamp	  NOT NULL	COMMENT '티켓 등급',
+    `grade_name`	    varchar(20)	  NOT NULL	COMMENT '티켓 등급 명칭',
+    `seat_count`        mediumint     NOT NULL	COMMENT '티켓 등급별 좌석 수',
+    `price`             decimal(18,6) NOT NULL  COMMENT '티켓 가격',
+    `created_dt`	    timestamp     NULL DEFAULT NOW() COMMENT '티켓 생성일시',
+    `ticket_id`	        bigint	      NOT NULL	COMMENT '티켓 ID'
+);
+
+-- 티켓 예매 내역
+DROP TABLE IF EXISTS `ticket_order`;
+CREATE TABLE `ticket_order` (
+    `ticket_order_id`	bigint	      NOT NULL AUTO_INCREMENT PRIMARY KEY	COMMENT '티켓 SID',
+    `member_id`         bigint        NOT NULL    COMMENT '회원 ID',
+    `performance_id`    bigint        NOT NULL    COMMENT '공연 ID',
+    `ticket_grade_id`   bigint        NOT NULL    COMMENT '티켓 등급 ID',
+    `created_dt`	    timestamp     NULL DEFAULT NOW() COMMENT '티켓 생성일시'
 );

--- a/src/main/java/com/ticketpark/ticket/member/controller/MemberController.java
+++ b/src/main/java/com/ticketpark/ticket/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.ticketpark.ticket.member.controller.request.MemberJoinRequest;
 import com.ticketpark.ticket.member.controller.response.MemberJoinResponse;
 import com.ticketpark.ticket.member.model.entity.Member;
 import com.ticketpark.ticket.member.service.MemberService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,7 +17,7 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/join")
-    public Response<MemberJoinResponse> join(@RequestBody MemberJoinRequest request){
+    public Response<MemberJoinResponse> join(@RequestBody @Valid MemberJoinRequest request){
         Member member = memberService.join(request.fromJoinRequest(request));
         return Response.success(MemberJoinResponse.fromMember(member));
     }

--- a/src/main/java/com/ticketpark/ticket/member/controller/request/MemberJoinRequest.java
+++ b/src/main/java/com/ticketpark/ticket/member/controller/request/MemberJoinRequest.java
@@ -3,6 +3,8 @@ package com.ticketpark.ticket.member.controller.request;
 import com.ticketpark.ticket.member.model.dto.MemberDto;
 import com.ticketpark.ticket.member.model.entity.Role;
 import com.ticketpark.ticket.member.model.entity.MemberStatus;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 import java.sql.Timestamp;
@@ -13,9 +15,13 @@ import java.time.Instant;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MemberJoinRequest {
+    @NotBlank(message = "아이디는 입력하세요")
     private String id;
     private Role role;
+    @NotBlank(message = "비밀번호는 입력하세요")
     private String password;
+    @Email(message = "이메일 형식이 맞지 않습니다")
+    @NotBlank(message = "이메일을 입력하세요")
     private String email;
     private String hp_no;
     private Timestamp created_dt;

--- a/src/main/java/com/ticketpark/ticket/member/model/dto/MemberDto.java
+++ b/src/main/java/com/ticketpark/ticket/member/model/dto/MemberDto.java
@@ -17,12 +17,9 @@ import java.sql.Timestamp;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MemberDto {
-    @NotBlank
     private String id;
     private Role role;
-    @NotBlank
     private String password;
-    @Email
     private String email;
     private String hp_no;
     private Timestamp created_dt;

--- a/src/main/java/com/ticketpark/ticket/member/model/entity/Member.java
+++ b/src/main/java/com/ticketpark/ticket/member/model/entity/Member.java
@@ -10,7 +10,7 @@ import java.sql.Timestamp;
 @Setter
 public class Member {
     //회원 SID
-    private Long member_sid;
+    private Long member_id;
     //아이디
     private String id;
     //비밀번호

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -5,12 +5,12 @@
 <mapper namespace="com.ticketpark.ticket.member.repository.MemberMapper">
 
     <select id="findById" resultType="com.ticketpark.ticket.member.model.entity.Member">
-        select member_sid, id, role, email, hp_no, created_dt, updated_dt, use_yn
+        select member_id, id, role, email, hp_no, created_dt, updated_dt, use_yn
         from member
         where id = #{id} and use_yn = 'Y'
     </select>
 
-    <insert id = "addMember" useGeneratedKeys="true" keyColumn="member_sid" keyProperty="member_sid" >
+    <insert id = "addMember" useGeneratedKeys="true" keyColumn="member_sid" keyProperty="member_id" >
         insert into member (id, role, password, email, hp_no, created_dt)
         values (#{member.id}, #{member.role}, #{member.password}, #{member.email}, #{member.hp_no}, #{member.created_dt})
     </insert>

--- a/src/test/java/com/ticketpark/ticket/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/ticketpark/ticket/member/controller/MemberControllerTest.java
@@ -1,5 +1,6 @@
 package com.ticketpark.ticket.member.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ticketpark.ticket.member.controller.request.MemberJoinRequest;
 import com.ticketpark.ticket.member.model.dto.MemberDto;
@@ -10,6 +11,7 @@ import com.ticketpark.ticket.member.repository.MemberRepository;
 import com.ticketpark.ticket.member.service.MemberService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +21,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -32,10 +35,10 @@ public class MemberControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    @Mock
+    @MockBean
     private MemberService memberService;
 
-    @Autowired
+    @MockBean
     private MemberRepository memberRepository;
 
     @Autowired
@@ -56,19 +59,28 @@ public class MemberControllerTest {
     }
 
     @Test
-    void 회원가입() throws Exception {
+    @DisplayName("회원가입 request 유효성 체크")
+    void validateMemberJoinRequest() throws Exception {
+        request.setId("");
+        request.setPassword("");
+        request.setRole(null);
+        request.setEmail("abc@@.com");
 
-        //TODO @MockBean 오류 왜 나는지 파악 필요함
-        when(memberService.join(request.fromJoinRequest(request))).thenReturn(mock(Member.class));
+        when(memberService.join(any())).thenReturn(mock(Member.class));
+        mvc.perform(post("/api/member/join").contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(request))).andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+
+    @Test
+    @DisplayName("회원가입")
+    void joinMember() throws Exception {
+        when(memberService.join(any())).thenReturn(mock(Member.class));
         mvc.perform(post("/api/member/join").contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(request))).andDo(print())
                 .andExpect(status().isOk());
     }
 
-    @AfterEach
-    void afterEach() {
-        //기존 데이터 제거
-        //TODO @Mock이면 여기 제대로 실행 안됨
-        memberRepository.deleteMember(request.getId());
-    }
+
 }

--- a/src/test/java/com/ticketpark/ticket/member/controller/request/MemberJoinRequestTest.java
+++ b/src/test/java/com/ticketpark/ticket/member/controller/request/MemberJoinRequestTest.java
@@ -1,0 +1,98 @@
+package com.ticketpark.ticket.member.controller.request;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ticketpark.ticket.member.model.entity.Role;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Slf4j
+@SpringBootTest
+public class MemberJoinRequestTest {
+
+    @Autowired
+    private Validator validator;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    private MemberJoinRequest request;
+
+    @BeforeEach
+    void beforeEach() {
+        request = new MemberJoinRequest();
+        request.setId("id");
+        request.setPassword("1q2w3e4r");
+        request.setEmail("abc@abc.com");
+    }
+
+
+    @DisplayName("회원가입 필수입력 항목 검증(아이디, 패스워드, 이메일)")
+    @Test
+    void checkRequiredInput() {
+        //given
+        request.setId("");
+        request.setPassword("");
+        request.setEmail("");
+
+        //when
+        List<String> validateMessage = this.getValidateMessage(request);
+
+        //then
+        assertThat(validateMessage).contains("아이디는 입력하세요", "비밀번호는 입력하세요", "이메일을 입력하세요");
+    }
+
+    @DisplayName("회원가입 이메일 포맷 확인")
+    @Test
+    void checkEmailFormat(){
+        //given
+        request.setEmail("abcd@");
+
+        //when
+        List<String> validateMessage = this.getValidateMessage(request);
+
+        //then
+        assertThat(validateMessage).contains("이메일 형식이 맞지 않습니다");
+    }
+    
+    @DisplayName("enum 값 유효성 체크")
+    @Test
+    void checkEnumValue() throws JsonProcessingException {
+        //given
+        String enumValue = "test";
+        //when
+        Role memberRole = Role.from(enumValue);
+        //then
+        assertThat(memberRole).isNull();
+    }
+    
+    
+    //유효성 위반 메시지 리턴
+    private List<String> getValidateMessage(MemberJoinRequest request){
+        Set<ConstraintViolation<MemberJoinRequest>> validate = validator.validate(request);
+
+        Iterator<ConstraintViolation<MemberJoinRequest>> iterator = validate.iterator();
+        List<String> messages = new ArrayList<>();
+        while (iterator.hasNext()) {
+            ConstraintViolation<MemberJoinRequest> next = iterator.next();
+            messages.add(next.getMessage());
+        }
+        return messages;
+    }
+
+
+
+}

--- a/src/test/java/com/ticketpark/ticket/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ticketpark/ticket/member/service/MemberServiceTest.java
@@ -43,11 +43,10 @@ public class MemberServiceTest {
     @Test
     void 회원가입_정상_동작(){
         //when
-        Member join = memberService.join(dto);
-        Optional<Member> memberById = memberRepository.findById(dto.getId());
-
+        Member joinedMember = memberService.join(dto);
+        Member searchedMember = memberRepository.findById(dto.getId()).orElseGet(Member::new);
         //then
-        assertThat(dto.getId()).isEqualTo(memberById.get().getId());
+        assertThat(joinedMember.getId()).isEqualTo(searchedMember.getId());
     }
 
     @Test


### PR DESCRIPTION
### @Valid / @JsonCreator 관련 테스트케이스 추가
#### 주요 수정 파일
- MemberControllerTest.java
    - validateMemberJoinRequest 테스트 메소드 추가 
    - 유효하지 않은 request는 400 error 응답 확인하는 방향으로 수정
 ex) 예시코드
![image](https://github.com/user-attachments/assets/88057e7d-1207-4344-bba6-19fb71ee6ea1)

- MemberJoinRequestTest.java
  - @Valid : jakarta.validation의 라이브러리 사용하여 오류 메세지 비교하는 방식으로 구현
ex)  jakarta.validation 라이브러리 사용한 예시
![image](https://github.com/user-attachments/assets/bf820eaf-e0a6-4e15-bee1-224c9f748fca)

  - @JsonCreator : @JsonCreator 어노테이션 붙은 함수 호출하여
    enum value에 해당되지 않는 값은 null 리턴받을거라 예상하여
    enum value와 매칭되지 않는 값은 null과 비교하는 방향으로 수정
    ex) Role.java
![image](https://github.com/user-attachments/assets/249b125e-1374-493b-ae75-5b3a61254ad7)
ex) checkEnumValue 메소드
![image](https://github.com/user-attachments/assets/cb63a29d-6870-4517-878e-91c1e6aa0d84)