### PR TITLE
[#4]공연/티켓 추가 및 테스트케이스 작성

### DIFF
--- a/src/main/java/com/ticketpark/exception/ErrorCode.java
+++ b/src/main/java/com/ticketpark/exception/ErrorCode.java
@@ -7,7 +7,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorCode {
     DUPLICATE_ID(TicketParkHttpStatus.RESOURCE_CONFLICT,"이미 가입된 아이디입니다.");
-
     private final TicketParkHttpStatus status;
     private final String message;
 }

--- a/src/main/java/com/ticketpark/performance/controller/PerformanceController.java
+++ b/src/main/java/com/ticketpark/performance/controller/PerformanceController.java
@@ -17,12 +17,11 @@ public class PerformanceController {
 
     private final PerformanceService performanceService;
 
-    @PostMapping("/addPerformance")
-    public Response<Void> addPerformance(List<PerformanceCreateRequest> requestList) {
-        //TODO 관리자 인증 추가 필요
-
+    @PostMapping("/createPerformance")
+    public Response<Void> createPerformance(PerformanceCreateRequest requestList) {
+        //TODO 공연은 관리자만 등록 가능하므로 관리자 체크는 AOP로 뺄 것
         //공연 추가
-        performanceService.addPerformance(requestList);
+        performanceService.createPerformance(requestList);
         return Response.success();
     }
 }

--- a/src/main/java/com/ticketpark/performance/controller/response/PerformanceCreateResponse.java
+++ b/src/main/java/com/ticketpark/performance/controller/response/PerformanceCreateResponse.java
@@ -1,22 +1,14 @@
-package com.ticketpark.performance.controller.request;
+package com.ticketpark.performance.controller.response;
 
-import com.ticketpark.performance.model.dto.PerformanceCreateDto;
 import com.ticketpark.performance.model.dto.PerformanceDto;
 import com.ticketpark.performance.model.dto.PerformerDto;
-import com.ticketpark.performance.model.entity.Genre;
 import com.ticketpark.ticket.model.dto.TicketDto;
 import com.ticketpark.ticket.model.dto.TicketGradeDto;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
-@Getter
-@Setter
-public class PerformanceCreateRequest {
+public class PerformanceCreateResponse {
     //공연정보
     @NotNull
     private PerformanceDto performance;

--- a/src/main/java/com/ticketpark/performance/model/dto/PerformanceDto.java
+++ b/src/main/java/com/ticketpark/performance/model/dto/PerformanceDto.java
@@ -11,7 +11,6 @@ import java.time.LocalDateTime;
 
 @Getter
 @Setter
-@AllArgsConstructor
 public class PerformanceDto {
     private Genre genre;
     private String name;

--- a/src/main/java/com/ticketpark/performance/model/entity/Performance.java
+++ b/src/main/java/com/ticketpark/performance/model/entity/Performance.java
@@ -19,13 +19,16 @@ public class Performance {
     private LocalDateTime created_at;
 
     public static Performance of(PerformanceCreateRequest request) {
+        PerformanceDto dto = request.getPerformance();
+
         Performance performance = new Performance();
-        performance.setGenre(request.getGenre());
-        performance.setName(request.getName());
-        performance.setPlace(request.getPlace());
-        performance.setStart_dt(request.getStart_dt());
-        performance.setEnd_dt(request.getEnd_dt());
+        performance.setGenre(dto.getGenre());
+        performance.setName(dto.getName());
+        performance.setPlace(dto.getPlace());
+        performance.setStart_dt(dto.getStart_dt());
+        performance.setEnd_dt(dto.getEnd_dt());
         performance.setCreated_at(LocalDateTime.now());
+
         return performance;
     }
 }

--- a/src/main/java/com/ticketpark/performance/model/entity/Performer.java
+++ b/src/main/java/com/ticketpark/performance/model/entity/Performer.java
@@ -15,17 +15,17 @@ public class Performer {
     private String name;
     private Long performance_id;
 
-    public static List<Performer> getPerformerList(PerformanceCreateRequest request){
-        List<Performer> result = new ArrayList<Performer>();
+    public static List<Performer> getPerformerList(Long performanceId, PerformanceCreateRequest request){
+        List<Performer> list = new ArrayList<Performer>();
         List<PerformerDto> requestList = request.getPerformer();
 
         for (PerformerDto dto : requestList) {
             Performer performer = new Performer();
             performer.setName(dto.getName());
-            performer.setPerformance_id(request.getPerformance_id());
-            result.add(performer);
+            performer.setPerformance_id(performanceId);
+            list.add(performer);
         }
-        return result;
+        return list;
     }
 
 

--- a/src/main/java/com/ticketpark/performance/repository/PerformerMapper.java
+++ b/src/main/java/com/ticketpark/performance/repository/PerformerMapper.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 @Mapper
 public interface PerformerMapper {
-    void createPerformer(List<Performer> performer);
+    void createPerformer(List<Performer> performerList);
 }

--- a/src/main/java/com/ticketpark/performance/service/PerformanceService.java
+++ b/src/main/java/com/ticketpark/performance/service/PerformanceService.java
@@ -1,33 +1,53 @@
 package com.ticketpark.performance.service;
 
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import com.ticketpark.exception.TicketParkException;
 import com.ticketpark.performance.controller.request.PerformanceCreateRequest;
 import com.ticketpark.performance.model.dto.PerformanceCreateDto;
 import com.ticketpark.performance.model.entity.Performance;
 import com.ticketpark.performance.model.entity.Performer;
 import com.ticketpark.performance.repository.PerformanceRepository;
 import com.ticketpark.performance.repository.PerformerRepository;
+import com.ticketpark.ticket.model.dto.TicketCreateDto;
+import com.ticketpark.ticket.model.dto.TicketDto;
+import com.ticketpark.ticket.service.TicketService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class PerformanceService {
 
     private final PerformanceRepository performanceRepository;
-    private final PerformerRepository performerRepository;
+        private final PerformerRepository performerRepository;
+        private final TicketService ticketService;
 
-    @Transactional
-    public void addPerformance(List<PerformanceCreateRequest> requestList) {
-        requestList.forEach(request -> {
-            Performance performance = Performance.of(request);
+        @Transactional
+        public void createPerformance(PerformanceCreateRequest request) {
+            //----------------------------
+            //공연(공연 + 가수) 등록
+            //----------------------------
             //공연 등록
+            Performance performance = Performance.of(request);
             performanceRepository.createPerformance(performance);
-            //공연 가수 정보 등록
-            request.setPerformance_id(performance.getPerformance_id());
-            performerRepository.createPerformer(Performer.getPerformerList(request));
-        });
-    }
+
+            Long performanceId = performance.getPerformance_id();
+            Optional.ofNullable(performanceId).orElseThrow(() ->
+                new IllegalArgumentException("table Performance pk is null")
+            );
+            //가수 등록
+            performerRepository.createPerformer(Performer.getPerformerList(performanceId, request));
+            //----------------------------
+            //티켓 등록(티켓 정보 + 좌석 등급)
+            //----------------------------
+            //티켓과 공연 key 언걸
+            TicketCreateDto ticketDto = TicketCreateDto.fromRequest(request);
+            Optional.ofNullable(ticketDto.getTicket()).orElseThrow(() ->
+                new IllegalArgumentException("ticket request is null")
+            );
+            request.getTicket().setPerformance_id(performanceId);
+            ticketService.createTicket(ticketDto);
+        }
 }

--- a/src/main/java/com/ticketpark/ticket/model/dto/TicketCreateDto.java
+++ b/src/main/java/com/ticketpark/ticket/model/dto/TicketCreateDto.java
@@ -1,0 +1,18 @@
+package com.ticketpark.ticket.model.dto;
+
+import com.ticketpark.performance.controller.request.PerformanceCreateRequest;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class TicketCreateDto {
+    private TicketDto ticket;
+    private List<TicketGradeDto> ticketGrade;
+
+    public static TicketCreateDto fromRequest(PerformanceCreateRequest request){
+        return new TicketCreateDto(request.getTicket(), request.getTicketGrade());
+    }
+}

--- a/src/main/java/com/ticketpark/ticket/model/dto/TicketDto.java
+++ b/src/main/java/com/ticketpark/ticket/model/dto/TicketDto.java
@@ -1,0 +1,19 @@
+package com.ticketpark.ticket.model.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class TicketDto {
+    //티켓 예매 시작 시간
+    private LocalDateTime start_dt;
+    //티켓 예매 종료 시간
+    private LocalDateTime end_dt;
+    //티켓 생성 시간(이력용)
+    private LocalDateTime created_dt;
+    //performance 테이블 pk
+    private Long performance_id;
+}

--- a/src/main/java/com/ticketpark/ticket/model/dto/TicketGradeDto.java
+++ b/src/main/java/com/ticketpark/ticket/model/dto/TicketGradeDto.java
@@ -1,0 +1,31 @@
+package com.ticketpark.ticket.model.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class TicketGradeDto {
+    //티켓 등급
+    private String grade;
+    //티켓 등급 명
+    private String grade_name;
+    //티켓 등급별 좌석 수
+    private Integer seat_count;
+    //티켓 좌석 수
+    private Double price;
+    //티켓 등급 생성 일시(이력용)
+    private LocalDateTime created_dt;
+    //티켓 테이블 pk
+    private Long ticket_id;
+
+    public TicketGradeDto(String grade, String grade_name, Integer seat_count, Double price, LocalDateTime created_dt) {
+        this.grade = grade;
+        this.grade_name = grade_name;
+        this.seat_count = seat_count;
+        this.price = price;
+        this.created_dt = created_dt;
+    }
+}
+
+

--- a/src/main/java/com/ticketpark/ticket/model/entity/Ticket.java
+++ b/src/main/java/com/ticketpark/ticket/model/entity/Ticket.java
@@ -1,16 +1,33 @@
 package com.ticketpark.ticket.model.entity;
 
+import com.ticketpark.ticket.model.dto.TicketDto;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.cglib.core.Local;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 @Getter
 @Setter
 public class Ticket {
+    //pk
     private Long ticket_id;
-    private Timestamp start_dt;
-    private Timestamp end_dt;
-    private Timestamp created_dt;
+    //티켓 예매 시작 시간
+    private LocalDateTime start_dt;
+    //티켓 예매 종료 시간
+    private LocalDateTime end_dt;
+    //티켓 생성 일시(이력용)
+    private LocalDateTime created_dt;
+    //performance 테이블 pk
     private Long performance_id;
+
+    public static Ticket of(TicketDto dto){
+        Ticket ticket = new Ticket();
+        ticket.setStart_dt(dto.getStart_dt());
+        ticket.setEnd_dt(dto.getEnd_dt());
+        ticket.setCreated_dt(dto.getCreated_dt());
+        ticket.setPerformance_id(dto.getPerformance_id());
+        return ticket;
+    }
 }

--- a/src/main/java/com/ticketpark/ticket/model/entity/Ticket_grade.java
+++ b/src/main/java/com/ticketpark/ticket/model/entity/Ticket_grade.java
@@ -1,18 +1,49 @@
 package com.ticketpark.ticket.model.entity;
 
+import com.ticketpark.performance.controller.request.PerformanceCreateRequest;
+import com.ticketpark.performance.model.dto.PerformerDto;
+import com.ticketpark.performance.model.entity.Performer;
+import com.ticketpark.ticket.model.dto.TicketGradeDto;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
 public class Ticket_grade {
+    //pk
     private Long ticket_grade_id;
+    //티켓 등급
     private String grade;
+    //티켓 등급 명칭
     private String grade_name;
+    //티켓 등급별 좌석 수
     private Integer seat_count;
-    private Integer price;
-    private Timestamp created_dt;
+    //티켓 가격
+    private Double price;
+    //티켓 등급 생성 일시(이력용)
+    private LocalDateTime created_dt;
+    //ticket 테이블 pk
     private Long ticket_id;
+
+    public static List<Ticket_grade> getPerformerList(Long ticketId, List<TicketGradeDto> gradeList){
+        List<Ticket_grade> list = new ArrayList<>();
+
+        for (TicketGradeDto dto : gradeList) {
+            Ticket_grade grade = new Ticket_grade();
+            grade.setGrade(dto.getGrade());
+            grade.setGrade_name(dto.getGrade_name());
+            grade.setSeat_count(dto.getSeat_count());
+            grade.setPrice(dto.getPrice());
+            grade.setCreated_dt(LocalDateTime.now());
+            grade.setTicket_id(ticketId);
+
+            list.add(grade);
+        }
+        return list;
+    }
 }

--- a/src/main/java/com/ticketpark/ticket/repository/MybatisTicketGradeRepository.java
+++ b/src/main/java/com/ticketpark/ticket/repository/MybatisTicketGradeRepository.java
@@ -1,0 +1,19 @@
+package com.ticketpark.ticket.repository;
+
+import com.ticketpark.ticket.model.entity.Ticket_grade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class MybatisTicketGradeRepository implements TicketGradeRepository{
+
+    private final TicketGradeMapper ticketGradeMapper;
+
+    @Override
+    public void createTicketGrade(List<Ticket_grade> ticketGradeList) {
+        ticketGradeMapper.createTicketGrade(ticketGradeList);
+    }
+}

--- a/src/main/java/com/ticketpark/ticket/repository/MybatisTicketRepository.java
+++ b/src/main/java/com/ticketpark/ticket/repository/MybatisTicketRepository.java
@@ -1,0 +1,17 @@
+package com.ticketpark.ticket.repository;
+
+import com.ticketpark.ticket.model.entity.Ticket;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MybatisTicketRepository implements TicketRepository{
+
+    private final TicketMapper ticketMapper;
+
+    @Override
+    public void createTicket(Ticket ticket) {
+        ticketMapper.createTicket(ticket);
+    }
+}

--- a/src/main/java/com/ticketpark/ticket/repository/TicketGradeMapper.java
+++ b/src/main/java/com/ticketpark/ticket/repository/TicketGradeMapper.java
@@ -1,0 +1,11 @@
+package com.ticketpark.ticket.repository;
+
+import com.ticketpark.ticket.model.entity.Ticket_grade;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface TicketGradeMapper {
+    void createTicketGrade(List<Ticket_grade> ticketGradeList);
+}

--- a/src/main/java/com/ticketpark/ticket/repository/TicketGradeRepository.java
+++ b/src/main/java/com/ticketpark/ticket/repository/TicketGradeRepository.java
@@ -1,0 +1,9 @@
+package com.ticketpark.ticket.repository;
+
+import com.ticketpark.ticket.model.entity.Ticket_grade;
+
+import java.util.List;
+
+public interface TicketGradeRepository {
+    void createTicketGrade(List<Ticket_grade> ticketGradeList);
+}

--- a/src/main/java/com/ticketpark/ticket/repository/TicketMapper.java
+++ b/src/main/java/com/ticketpark/ticket/repository/TicketMapper.java
@@ -1,0 +1,11 @@
+package com.ticketpark.ticket.repository;
+
+import com.ticketpark.ticket.model.entity.Ticket;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface TicketMapper {
+    void createTicket(@Param("ticket") Ticket ticket);
+}
+

--- a/src/main/java/com/ticketpark/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/ticketpark/ticket/repository/TicketRepository.java
@@ -1,0 +1,7 @@
+package com.ticketpark.ticket.repository;
+
+import com.ticketpark.ticket.model.entity.Ticket;
+
+public interface TicketRepository {
+    void createTicket(Ticket ticket);
+}

--- a/src/main/java/com/ticketpark/ticket/service/TicketService.java
+++ b/src/main/java/com/ticketpark/ticket/service/TicketService.java
@@ -1,0 +1,52 @@
+package com.ticketpark.ticket.service;
+
+import com.ticketpark.common.response.Response;
+import com.ticketpark.ticket.model.dto.TicketCreateDto;
+import com.ticketpark.ticket.model.entity.Ticket;
+import com.ticketpark.ticket.model.entity.Ticket_grade;
+import com.ticketpark.ticket.repository.TicketGradeRepository;
+import com.ticketpark.ticket.repository.TicketRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class TicketService {
+    
+    private final TicketRepository ticketRepository;
+    private final TicketGradeRepository ticketGradeRepository;
+    
+    @Transactional(propagation = Propagation.MANDATORY)
+    public Response<Void> createTicket(TicketCreateDto dto) {
+        //티켓은 무조건 공연이랑 세트로 저장하기에 전파옵션 MANDATORY
+        /*
+        * 의미: 트랜잭션이 의무임(트랜잭션이 반드시 필요함)
+        기존 트랜잭션 없음: IllegalTransactionStateException 예외 발생
+        기존 트랜잭션이 있음: 기존 트랜잭션에 참여함
+        *
+        * */
+
+        //----------------------------
+        //티켓 정보 등록
+        //----------------------------
+        Ticket ticket = Ticket.of(dto.getTicket());
+        ticketRepository.createTicket(ticket);
+
+        //----------------------------
+        //좌석 정보 등록
+        //----------------------------
+        Long ticketId = ticket.getTicket_id();
+        Optional.ofNullable(ticketId).orElseThrow(() ->
+            new IllegalArgumentException("table Ticket pk is null")
+        );
+
+        ticketGradeRepository.createTicketGrade(Ticket_grade.getPerformerList(ticketId, dto.getTicketGrade()));
+
+        return Response.success();
+    }
+
+}

--- a/src/main/resources/mapper/PerformerMapper.xml
+++ b/src/main/resources/mapper/PerformerMapper.xml
@@ -7,8 +7,8 @@
         insert into performer (name, performance_id) values
         <foreach collection="list" index = "index" item = "performer" separator=",">
             (
-            #{performer.name},
-            #{performer.performance_id}
+                #{performer.name}
+               ,#{performer.performance_id}
             )
         </foreach>
     </insert>

--- a/src/main/resources/mapper/TicketGradeMapper.xml
+++ b/src/main/resources/mapper/TicketGradeMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.ticketpark.ticket.repository.TicketGradeMapper">
+    <insert id = "createTicketGrade" useGeneratedKeys="true" keyColumn="ticket_grade_id" keyProperty="ticket_grade_id">
+        insert into ticket_grade(grade, grade_name, seat_count, price, created_dt, ticket_id) values
+            <foreach collection="list" index="index" item="ticket_grade" separator=",">
+            (
+                 #{ticket_grade.grade}
+                ,#{ticket_grade.grade_name}
+                ,#{ticket_grade.seat_count}
+                ,#{ticket_grade.price}
+                ,#{ticket_grade.created_dt}
+                ,#{ticket_grade.ticket_id}
+            )
+        </foreach>
+    </insert>
+</mapper>

--- a/src/main/resources/mapper/TicketMapper.xml
+++ b/src/main/resources/mapper/TicketMapper.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.ticketpark.ticket.repository.TicketMapper">
+    <insert id = "createTicket" useGeneratedKeys="true" keyColumn="ticket_id" keyProperty="ticket_id" >
+        insert into ticket (start_dt, end_dt, created_dt, performance_id)
+        values(#{ticket.start_dt}, #{ticket.end_dt}, #{ticket.created_dt}, #{ticket.performance_id})
+    </insert>
+</mapper>

--- a/src/test/java/com/ticketpark/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/ticketpark/member/controller/MemberControllerTest.java
@@ -3,6 +3,7 @@ package com.ticketpark.member.controller;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ticketpark.member.controller.request.MemberJoinRequest;
+import com.ticketpark.member.fixture.MemberFixture;
 import com.ticketpark.member.model.entity.Member;
 import com.ticketpark.member.model.entity.MemberStatus;
 import com.ticketpark.member.model.entity.Role;
@@ -47,14 +48,7 @@ public class MemberControllerTest {
 
     @BeforeEach
     void beforeEach() {
-        //초기 데이터 셋팅
-        request = new MemberJoinRequest();
-        request.setId("idTest1");
-        request.setRole(Role.USER);
-        request.setPassword("1q2w3e4r");
-        request.setEmail("aa@aa.com");
-        request.setHp_no("01012345678");
-        request.setUse_yn(MemberStatus.USE);
+        request = MemberFixture.getJoinRequest();
     }
 
     @Test

--- a/src/test/java/com/ticketpark/member/fixture/MemberFixture.java
+++ b/src/test/java/com/ticketpark/member/fixture/MemberFixture.java
@@ -1,0 +1,29 @@
+package com.ticketpark.member.fixture;
+
+import com.ticketpark.member.controller.request.MemberJoinRequest;
+import com.ticketpark.member.model.dto.MemberDto;
+import com.ticketpark.member.model.entity.MemberStatus;
+import com.ticketpark.member.model.entity.Role;
+import lombok.Data;
+
+public class MemberFixture {
+
+    public static MemberJoinRequest getJoinRequest() {
+        MemberJoinRequest request = new MemberJoinRequest();
+
+        request = new MemberJoinRequest();
+        request.setId("idTest1");
+        request.setRole(Role.USER);
+        request.setPassword("1q2w3e4r");
+        request.setEmail("aa@aa.com");
+        request.setHp_no("01012345678");
+        request.setUse_yn(MemberStatus.USE);
+
+        return request;
+    }
+
+    public static MemberDto getMemberDto() {
+        MemberJoinRequest request = MemberFixture.getJoinRequest();
+        return request.fromJoinRequest(request);
+    }
+}

--- a/src/test/java/com/ticketpark/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ticketpark/member/service/MemberServiceTest.java
@@ -31,7 +31,7 @@ public class MemberServiceTest {
     void beforeEach() {
         //테스트 데이터 셋팅
         dto = new MemberDto();
-        dto.setId("idTest1");
+        dto.setId("idTest2");
         dto.setRole(Role.USER);
         dto.setPassword("1q2w3e4r");
         dto.setEmail("aa@aa.com");

--- a/src/test/java/com/ticketpark/performance/controller/PerformanceControllerTest.java
+++ b/src/test/java/com/ticketpark/performance/controller/PerformanceControllerTest.java
@@ -1,44 +1,60 @@
-package com.ticketpark.performance.service;
+package com.ticketpark.performance.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ticketpark.member.model.entity.Member;
 import com.ticketpark.performance.controller.request.PerformanceCreateRequest;
 import com.ticketpark.performance.fixture.PerformanceFixture;
 import com.ticketpark.performance.fixture.PerformerFixture;
 import com.ticketpark.performance.model.dto.PerformanceDto;
 import com.ticketpark.performance.model.dto.PerformerDto;
 import com.ticketpark.performance.model.entity.Genre;
-import com.ticketpark.performance.model.entity.Performer;
+import com.ticketpark.performance.model.entity.Performance;
+import com.ticketpark.performance.service.PerformanceService;
 import com.ticketpark.ticket.model.dto.TicketDto;
 import com.ticketpark.ticket.model.dto.TicketGradeDto;
 import com.ticketpark.ticket.service.fixture.TicketFixture;
 import com.ticketpark.ticket.service.fixture.TicketGradeFixture;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
-public class PerformanceServiceTest {
+@AutoConfigureMockMvc
+public class PerformanceControllerTest{
+
     @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
     private PerformanceService performanceService;
 
     private PerformanceCreateRequest request;
 
     @BeforeEach
-    void beforeEach(){
+    public void setUp() throws Exception {
         request = new PerformanceCreateRequest();
-        // 공연
+        //공연
         request.setPerformance(PerformanceFixture.getPerformanceDto());
         //가수 정보
         request.setPerformer(PerformerFixture.getPerformerDtoList());
@@ -48,18 +64,11 @@ public class PerformanceServiceTest {
         request.setTicketGrade(TicketGradeFixture.getLitTicketGradeDto());
     }
 
-    @DisplayName("공연/티켓정보 정상 동작")
+    @DisplayName("공연/티켓 정보 등록")
     @Test
-    void createPerformance(){
-        Assertions.assertDoesNotThrow(() -> performanceService.createPerformance(request));
+    void createPerformance() throws Exception {
+        mvc.perform(post("/api/performance/createPerformance").contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(request))).andDo(print())
+                .andExpect(status().isOk());
     }
-
-    @DisplayName("티켓 정보 없이 공연 등록 불가")
-    @Test
-    void createPerformanceWithoutTicket(){
-        request.setTicket(null);
-        request.setTicketGrade(null);
-        assertThrows(IllegalArgumentException.class, () -> performanceService.createPerformance(request));
-    }
-
 }

--- a/src/test/java/com/ticketpark/performance/fixture/PerformanceFixture.java
+++ b/src/test/java/com/ticketpark/performance/fixture/PerformanceFixture.java
@@ -1,0 +1,24 @@
+package com.ticketpark.performance.fixture;
+
+import com.ticketpark.performance.model.dto.PerformanceDto;
+import com.ticketpark.performance.model.entity.Genre;
+
+import java.time.LocalDateTime;
+
+public class PerformanceFixture {
+    public static PerformanceDto getPerformanceDto() {
+
+        LocalDateTime performanceStartTime = LocalDateTime.now().plusDays(10);
+        LocalDateTime performanceEndTime = LocalDateTime.now().plusDays(12);
+
+        PerformanceDto dto = new PerformanceDto();
+        dto.setGenre(Genre.CONCERT);
+        dto.setName("2024 SM 통합 콘서트");
+        dto.setPlace("고척돔");
+        dto.setStart_dt(performanceStartTime);
+        dto.setEnd_dt(performanceEndTime);
+        dto.setCreated_at(LocalDateTime.now());
+
+        return dto;
+    }
+}

--- a/src/test/java/com/ticketpark/performance/fixture/PerformerFixture.java
+++ b/src/test/java/com/ticketpark/performance/fixture/PerformerFixture.java
@@ -1,0 +1,17 @@
+package com.ticketpark.performance.fixture;
+
+import com.ticketpark.performance.model.dto.PerformerDto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PerformerFixture {
+
+    public static List<PerformerDto> getPerformerDtoList(){
+        List<PerformerDto> performerList =  new ArrayList<>();
+        performerList.add(new PerformerDto("에스파"));
+        performerList.add(new PerformerDto("NCT"));
+        performerList.add(new PerformerDto("라이즈"));
+        return performerList;
+    }
+}

--- a/src/test/java/com/ticketpark/ticket/service/TicketServiceTest.java
+++ b/src/test/java/com/ticketpark/ticket/service/TicketServiceTest.java
@@ -1,0 +1,41 @@
+package com.ticketpark.ticket.service;
+
+import com.ticketpark.ticket.model.dto.TicketCreateDto;
+import com.ticketpark.ticket.model.dto.TicketDto;
+import com.ticketpark.ticket.model.dto.TicketGradeDto;
+import com.ticketpark.ticket.service.fixture.TicketFixture;
+import com.ticketpark.ticket.service.fixture.TicketGradeFixture;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.IllegalTransactionStateException;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+@SpringBootTest
+public class TicketServiceTest {
+
+    @Autowired
+    private TicketService ticketService;
+
+    private TicketCreateDto request;
+
+    @BeforeEach
+    void setUp() {
+        request = new TicketCreateDto(TicketFixture.getTicketDto(), TicketGradeFixture.getLitTicketGradeDto());
+    }
+
+    @Test
+    @DisplayName("티켓은 공연과 같이 등록되어야 한다")
+    void addTicketWithoutPerformance(){
+        //티켓만 insert 시 트랜잭션 전파 옵션으로 인한 exception 발생
+        Assertions.assertThrows(IllegalTransactionStateException.class, () -> ticketService.createTicket(request));
+    }
+
+}

--- a/src/test/java/com/ticketpark/ticket/service/fixture/TicketFixture.java
+++ b/src/test/java/com/ticketpark/ticket/service/fixture/TicketFixture.java
@@ -1,0 +1,21 @@
+package com.ticketpark.ticket.service.fixture;
+
+import com.ticketpark.ticket.model.dto.TicketDto;
+import com.ticketpark.ticket.model.entity.Ticket;
+
+import java.time.LocalDateTime;
+
+public class TicketFixture {
+
+    public static TicketDto getTicketDto() {
+        LocalDateTime orderStartTime = LocalDateTime.now().plusDays(3);
+        LocalDateTime orderEndTime = LocalDateTime.now().plusDays(10);
+
+        TicketDto ticketDto = new TicketDto();
+        ticketDto.setStart_dt(orderStartTime);
+        ticketDto.setEnd_dt(orderEndTime);
+        ticketDto.setCreated_dt(LocalDateTime.now());
+
+        return ticketDto;
+    }
+}

--- a/src/test/java/com/ticketpark/ticket/service/fixture/TicketGradeFixture.java
+++ b/src/test/java/com/ticketpark/ticket/service/fixture/TicketGradeFixture.java
@@ -1,0 +1,18 @@
+package com.ticketpark.ticket.service.fixture;
+
+import com.ticketpark.ticket.model.dto.TicketGradeDto;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TicketGradeFixture {
+
+    public static List<TicketGradeDto> getLitTicketGradeDto() {
+        List<TicketGradeDto> gradeDtoList = new ArrayList<TicketGradeDto>();
+        gradeDtoList.add(new TicketGradeDto("VIP", "VIP석", 200, 200000.0, LocalDateTime.now()));
+        gradeDtoList.add(new TicketGradeDto("R", "R석", 200, 170000.0, LocalDateTime.now()));
+        gradeDtoList.add(new TicketGradeDto("S", "S석", 200, 150000.0, LocalDateTime.now()));
+        return gradeDtoList;
+    }
+}


### PR DESCRIPTION
### 공연/티켓 등록 api 추가
#### 공연/티켓 등록 관련 상세
- 공연 등록 시, 티켓 정보(티켓 정보, 좌석등급)도 함께 등록한다
	- 공연, 티켓 각각 단독으로 등록은 불가하다
#### 테스트 시나리오
- 공연
   - 공연, 가수, 티켓정보, 좌석정보 request 유효하면 정상 동작한다
   - 티켓 request 없이 공연 등록 불가하다

- 티켓
   - 티켓 단독으로 등록 불가하다.  무조건 공연과 함께 등록되어야 한다.
     티켓 단독 등록 트랜잭션 전파 관련 Exception(IllegalTransactionStateException) 리턴

### 공연/티켓 추가 도식도
![공연api](https://github.com/user-attachments/assets/4b6b231c-878f-4874-83b9-0aff1808c8e6)
