### PR TITLE
[#5] #3코드 리뷰 반영

### DIFF
--- a/src/main/java/com/ticketpark/common/response/Response.java
+++ b/src/main/java/com/ticketpark/common/response/Response.java
@@ -20,4 +20,7 @@ public class Response<T> {
     public static<T> Response<Void> error(String resultCode) {
         return new Response<Void>(resultCode, null);
     }
+    public static<T> Response<T> error(T result){
+        return new Response<T>("ERROR", result);
+    }
 }

--- a/src/main/java/com/ticketpark/configuration/mybatis/typeHandler/GenreTypeHandler.java
+++ b/src/main/java/com/ticketpark/configuration/mybatis/typeHandler/GenreTypeHandler.java
@@ -36,7 +36,7 @@ public class GenreTypeHandler implements TypeHandler<Genre> {
     }
 
     private Genre getGenre(String genreKey){
-        Genre genre = null;
+        Genre genre = Genre.CONCERT;
         switch (genreKey){
             case "CO":
                 genre = Genre.CONCERT;

--- a/src/main/java/com/ticketpark/configuration/mybatis/typeHandler/RoleTypeHandler.java
+++ b/src/main/java/com/ticketpark/configuration/mybatis/typeHandler/RoleTypeHandler.java
@@ -36,7 +36,7 @@ public class RoleTypeHandler implements TypeHandler<Role> {
     }
 
     private Role getMemberRole(String roleKey) {
-        Role role = null;
+        Role role = Role.USER;
         switch (roleKey) {
             case "A" :
                 role = Role.ADMIN;

--- a/src/main/java/com/ticketpark/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/ticketpark/exception/GlobalControllerAdvice.java
@@ -2,9 +2,13 @@ package com.ticketpark.exception;
 
 import com.ticketpark.common.response.Response;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
 
 @Slf4j
 @RestControllerAdvice
@@ -16,5 +20,19 @@ public class GlobalControllerAdvice {
 
         return ResponseEntity.status(e.getErrorCode().getStatus().getHttpCode())
                 .body(Response.error(e.getErrorCode().name()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> inValidRequestHandler(MethodArgumentNotValidException e) {
+        log.error("Error occurs {}", e.toString());
+
+        List<String> errorMessages = e.getBindingResult().getFieldErrors().stream().map(fieldError -> {
+            return String.format("%s./잘못 입력된 데이터 : [%s]"
+                    , fieldError.getDefaultMessage()
+                    , fieldError.getRejectedValue());
+        }).toList();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                            .body(Response.error(errorMessages));
     }
 }

--- a/src/main/java/com/ticketpark/member/controller/request/MemberJoinRequest.java
+++ b/src/main/java/com/ticketpark/member/controller/request/MemberJoinRequest.java
@@ -11,9 +11,6 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
 public class MemberJoinRequest {
     @NotBlank(message = "아이디는 입력하세요")
     private String id;
@@ -27,6 +24,16 @@ public class MemberJoinRequest {
     private LocalDateTime created_dt;
     private LocalDateTime updated_dt;
     private MemberStatus use_yn;
+
+    @Builder
+    public MemberJoinRequest(String id, Role role, String password, String email, String hp_no, MemberStatus use_yn){
+        this.id = id;
+        this.role = role;
+        this.password = password;
+        this.email = email;
+        this.hp_no = hp_no;
+        this.use_yn = use_yn;
+    }
 
     public MemberDto fromJoinRequest(MemberJoinRequest request){
         return new MemberDto(

--- a/src/main/java/com/ticketpark/member/model/dto/MemberDto.java
+++ b/src/main/java/com/ticketpark/member/model/dto/MemberDto.java
@@ -14,8 +14,6 @@ import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
-@NoArgsConstructor
 @AllArgsConstructor
 public class MemberDto {
     private String id;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,14 +2,5 @@ spring:
   docker:
     compose:
       file: docker-compose-dev.yml
-mybatis:
-  mapper-locations: classpath:mapper/*.xml
-  configuration:
-    map-underscore-to-camel-case: true
-    type-handlers-package: com.ticketpark.configuration.mybatis.typeHandler
-logging:
-  level:
-    com:
-      ticketpark:
-        mybatis: trace
+
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -2,14 +2,4 @@ spring:
   docker:
     compose:
       file: docker-compose-prod.yml
-mybatis:
-  mapper-locations: classpath:mapper/*.xml
-  configuration:
-    map-underscore-to-camel-case: true
-    type-handlers-package: com.ticketpark.configuration.mybatis.typeHandler
-logging:
-  level:
-    com:
-      ticketpark:
-        mybatis: trace
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,14 @@
 spring:
   profiles:
     active: prod
+mybatis:
+  mapper-locations: classpath:mapper/*.xml
+  type-handlers-package: com.ticketpark.configuration.mybatis.typeHandler
+  configuration:
+    map-underscore-to-camel-case: true
+    default-enum-type-handler:
+logging:
+  level:
+    com:
+      ticketpark:
+        mybatis: trace

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -10,7 +10,7 @@
         where id = #{id} and use_yn = 'Y'
     </select>
 
-    <insert id = "addMember" useGeneratedKeys="true" keyColumn="member_sid" keyProperty="member_id" >
+    <insert id = "addMember" useGeneratedKeys="true" keyColumn="member_id" keyProperty="member_id" >
         insert into member (id, role, password, email, hp_no, created_dt)
         values (#{member.id}, #{member.role}, #{member.password}, #{member.email}, #{member.hp_no}, #{member.created_dt})
     </insert>

--- a/src/test/java/com/ticketpark/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/ticketpark/member/controller/MemberControllerTest.java
@@ -1,19 +1,13 @@
 package com.ticketpark.member.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ticketpark.member.controller.request.MemberJoinRequest;
 import com.ticketpark.member.fixture.MemberFixture;
 import com.ticketpark.member.model.entity.Member;
-import com.ticketpark.member.model.entity.MemberStatus;
-import com.ticketpark.member.model.entity.Role;
 import com.ticketpark.member.repository.MemberRepository;
 import com.ticketpark.member.service.MemberService;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -46,18 +40,10 @@ public class MemberControllerTest {
 
     private MemberJoinRequest request;
 
-    @BeforeEach
-    void beforeEach() {
-        request = MemberFixture.getJoinRequest();
-    }
-
     @Test
     @DisplayName("회원가입 request 유효성 체크")
     void validateMemberJoinRequest() throws Exception {
-        request.setId("");
-        request.setPassword("");
-        request.setRole(null);
-        request.setEmail("abc@@.com");
+        request = MemberFixture.getEmptyRequiredInputJoinRequest();
 
         when(memberService.join(any())).thenReturn(mock(Member.class));
         mvc.perform(post("/api/member/join").contentType(MediaType.APPLICATION_JSON)
@@ -69,6 +55,8 @@ public class MemberControllerTest {
     @Test
     @DisplayName("회원가입")
     void joinMember() throws Exception {
+        request = MemberFixture.getJoinRequest();
+
         when(memberService.join(any())).thenReturn(mock(Member.class));
         mvc.perform(post("/api/member/join").contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(request))).andDo(print())

--- a/src/test/java/com/ticketpark/member/controller/request/MemberJoinRequestTest.java
+++ b/src/test/java/com/ticketpark/member/controller/request/MemberJoinRequestTest.java
@@ -2,6 +2,7 @@ package com.ticketpark.member.controller.request;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ticketpark.member.fixture.MemberFixture;
 import com.ticketpark.member.model.entity.Role;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
@@ -12,14 +13,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.util.ArrayList;
-import java.util.Iterator;
+import java.io.IOException;
 import java.util.List;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.*;
 
-@Slf4j
 @SpringBootTest
 public class MemberJoinRequestTest {
 
@@ -31,68 +29,37 @@ public class MemberJoinRequestTest {
 
     private MemberJoinRequest request;
 
-    @BeforeEach
-    void beforeEach() {
-        request = new MemberJoinRequest();
-        request.setId("id");
-        request.setPassword("1q2w3e4r");
-        request.setEmail("abc@abc.com");
-    }
-
-
     @DisplayName("회원가입 필수입력 항목 검증(아이디, 패스워드, 이메일)")
     @Test
     void checkRequiredInput() {
         //given
-        request.setId("");
-        request.setPassword("");
-        request.setEmail("");
+        request = MemberFixture.getEmptyRequiredInputJoinRequest();
 
         //when
         List<String> validateMessage = this.getValidateMessage(request);
 
         //then
-        assertThat(validateMessage).contains("아이디는 입력하세요", "비밀번호는 입력하세요", "이메일을 입력하세요");
+        assertThat(validateMessage).containsExactlyInAnyOrder("아이디는 입력하세요", "비밀번호는 입력하세요", "이메일을 입력하세요");
     }
 
     @DisplayName("회원가입 이메일 포맷 확인")
     @Test
     void checkEmailFormat(){
         //given
-        request.setEmail("abcd@");
+        request = MemberFixture.getInvalidEmailJoinRequest();
 
         //when
         List<String> validateMessage = this.getValidateMessage(request);
 
         //then
-        assertThat(validateMessage).contains("이메일 형식이 맞지 않습니다");
+        assertThat(validateMessage).containsExactly("이메일 형식이 맞지 않습니다");
     }
-    
-    @DisplayName("enum 값 유효성 체크")
-    @Test
-    void checkEnumValue() throws JsonProcessingException {
-        //given
-        String enumValue = "test";
-        //when
-        Role memberRole = Role.from(enumValue);
-        //then
-        assertThat(memberRole).isNull();
-    }
-    
-    
+
     //유효성 위반 메시지 리턴
     private List<String> getValidateMessage(MemberJoinRequest request){
-        Set<ConstraintViolation<MemberJoinRequest>> validate = validator.validate(request);
-
-        Iterator<ConstraintViolation<MemberJoinRequest>> iterator = validate.iterator();
-        List<String> messages = new ArrayList<>();
-        while (iterator.hasNext()) {
-            ConstraintViolation<MemberJoinRequest> next = iterator.next();
-            messages.add(next.getMessage());
-        }
-        return messages;
+        return validator.validate(request).stream()
+                .map(ConstraintViolation::getMessage)
+                .toList();
     }
-
-
 
 }

--- a/src/test/java/com/ticketpark/member/fixture/MemberFixture.java
+++ b/src/test/java/com/ticketpark/member/fixture/MemberFixture.java
@@ -4,22 +4,41 @@ import com.ticketpark.member.controller.request.MemberJoinRequest;
 import com.ticketpark.member.model.dto.MemberDto;
 import com.ticketpark.member.model.entity.MemberStatus;
 import com.ticketpark.member.model.entity.Role;
-import lombok.Data;
 
 public class MemberFixture {
 
+    //정상 request
     public static MemberJoinRequest getJoinRequest() {
-        MemberJoinRequest request = new MemberJoinRequest();
+        return MemberJoinRequest.builder()
+                .id("idTest")
+                .role(Role.USER)
+                .password("1q2w3e4r")
+                .email("aa@aa.com")
+                .hp_no("01012345678")
+                .use_yn(MemberStatus.USE)
+                .build();
+    }
 
-        request = new MemberJoinRequest();
-        request.setId("idTest1");
-        request.setRole(Role.USER);
-        request.setPassword("1q2w3e4r");
-        request.setEmail("aa@aa.com");
-        request.setHp_no("01012345678");
-        request.setUse_yn(MemberStatus.USE);
+    //필수입력값 빈 값 처리한 request
+    public static MemberJoinRequest getEmptyRequiredInputJoinRequest() {
+        return MemberJoinRequest.builder()
+                .id("")
+                .password("")
+                .email("")
+                .hp_no("01012345678")
+                .use_yn(MemberStatus.USE)
+                .build();
+    }
 
-        return request;
+    //이메일 포맷 문제있는 request
+    public static MemberJoinRequest getInvalidEmailJoinRequest() {
+        return MemberJoinRequest.builder()
+                .id("idTest")
+                .password("1q2w3e4r")
+                .email("invalid_Email_format_data")
+                .hp_no("01012345678")
+                .use_yn(MemberStatus.USE)
+                .build();
     }
 
     public static MemberDto getMemberDto() {

--- a/src/test/java/com/ticketpark/member/model/entity/RoleTest.java
+++ b/src/test/java/com/ticketpark/member/model/entity/RoleTest.java
@@ -1,0 +1,43 @@
+package com.ticketpark.member.model.entity;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class RoleTest {
+
+    private ObjectMapper mapper;
+
+    @DisplayName("잘못된 enum Role 데이터 파싱하는 경우")
+    @Test
+    void inValidRoleEnumData() throws IOException {
+        //given
+        mapper = new ObjectMapper();
+        String jsonString = "invalid_enum_role_data";
+
+        //when
+        Role role = mapper.readValue(mapper.writeValueAsBytes(jsonString), Role.class);
+
+        //then
+        assertThat(role).isNull();
+    }
+
+    @DisplayName("올바른 enum Role 데이터 파싱하는 경우")
+    @Test
+    void correctRoleEnumData() throws IOException {
+        //given
+        mapper = new ObjectMapper();
+        String jsonString = "U";
+
+        //when
+        Role role = mapper.readValue(mapper.writeValueAsBytes(jsonString), Role.class);
+
+        //then
+        assertThat(role).isNotNull();
+    }
+
+
+}

--- a/src/test/java/com/ticketpark/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ticketpark/member/service/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package com.ticketpark.member.service;
 
 import com.ticketpark.exception.TicketParkException;
+import com.ticketpark.member.fixture.MemberFixture;
 import com.ticketpark.member.model.dto.MemberDto;
 import com.ticketpark.member.model.entity.Member;
 import com.ticketpark.member.model.entity.MemberStatus;
@@ -8,6 +9,7 @@ import com.ticketpark.member.model.entity.Role;
 import com.ticketpark.member.repository.MemberRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -29,18 +31,14 @@ public class MemberServiceTest {
 
     @BeforeEach
     void beforeEach() {
-        //테스트 데이터 셋팅
-        dto = new MemberDto();
-        dto.setId("idTest2");
-        dto.setRole(Role.USER);
-        dto.setPassword("1q2w3e4r");
-        dto.setEmail("aa@aa.com");
-        dto.setHp_no("01012345678");
-        dto.setUse_yn(MemberStatus.USE);
+        dto = MemberFixture.getMemberDto();
+        //데이터 중복 제거
+        memberRepository.deleteMember(dto.getId());
     }
 
+    @DisplayName("회원가입 정상 동작")
     @Test
-    void 회원가입_정상_동작(){
+    void joinMember(){
         //when
         Member joinedMember = memberService.join(dto);
         Member searchedMember = memberRepository.findById(dto.getId()).orElseGet(Member::new);
@@ -48,18 +46,12 @@ public class MemberServiceTest {
         assertThat(joinedMember.getId()).isEqualTo(searchedMember.getId());
     }
 
+    @DisplayName("회원가입 시 아이디 중복되면 에러 발생")
     @Test
-    void 회원가입시_아이디중복되면_에러발생(){
+    void joinErrorByDuplicatedId(){
         //동일 아이디로 2번 가입 시 exception 발생
         Member join = memberService.join(dto);
         assertThrows(TicketParkException.class, () -> memberService.join(dto));
 
     }
-
-    @AfterEach
-    void afterEach() {
-        //기존 데이터 제거
-        memberRepository.deleteMember(dto.getId());
-    }
-
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -13,7 +13,7 @@ spring:
 mybatis:
   mapper-locations: classpath:mapper/*.xml
   configuration:
-    map-underscore-to-camel-case: 'true'
+    map-underscore-to-camel-case: true
   type-handlers-package: com.ticketpark.configuration.mybatis.typeHandler
 logging:
   level:


### PR DESCRIPTION
### 주요 변경 사항
- 실행 환경 변경
    - 개발 소스 : 도커에서 db 관리하도록 변경
        - application.yml
            - 운영, 개발 공통 설정 내용 
            - 운영/개발 뭘 바라볼지 profile 설정
             → spring.profiles.active = prod
        - 운영 서버 
            - application-prod.yml
            - docker-compose-prod.yml
        -  개발 서버
            - application-dev.yml
            - docker-compose-dev.yml
    - 테스트 소스 db h2 바라보도록 변경
        - 테스트 코드도 도커 적용하려 했으나 testContainer 적용한다면 속도 느려진다고 하여 추 후 redis, db 통합 테스트 필요한 경우에 사용 고려 중

- java validation 체크 간접 오류 체크 가능하도록 
ContorllerAdvice 수정
    - MethodArgumentNotValidException만 처리하는 handler 추가
- Request, Dto 불필요한 Setter, 생성자 제거
    - Setter, 불필요한 생성자 테스트 코드에서만 사용하고 있어서 필요한 필드만 생성자로 초기화
    ```
    ex) MemberJoinRequest.java
    @Builder
    public MemberJoinRequest(String id, Role role, String password, String email, String hp_no, MemberStatus use_yn){
        this.id = id;
        this.role = role;
        this.password = password;
        this.email = email;
        this.hp_no = hp_no;
        this.use_yn = use_yn;
    }
    ```
 - 테스트코드에서 데이터 셋팅하기 위해서 Setter 사용하던 부분은
 테스트 목적에 맞게 fixture 메소드로 분류
 ```
ex)MemberFixture.java
// 기본 리퀘스트
public static MemberJoinRequest getJoinRequest() {
        MemberJoinRequest request = new MemberJoinRequest();
        return MemberJoinRequest.builder()
                .id("idTest")
                .role(Role.USER)
                .password("1q2w3e4r")
                .email("aa@aa.com")
                .hp_no("01012345678")
                .use_yn(MemberStatus.USE)
                .build();
}

//필수입력 값 테스트 위한 request
public static MemberJoinRequest getEmptyRequiredInputJoinRequest() {
        return MemberJoinRequest.builder()
                .id("")
                .password("")
                .email("")
                .hp_no("01012345678")
                .use_yn(MemberStatus.USE)
                .build();
    }

 ```
 - @JsonCreator 테스트 위한 RoleTest.java 추가