### PR TITLE
[#8]티켓 예매 다양한 락 기법 적용 / 테스트 데이터 클리너 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-docker-compose'
 

--- a/db/initdb.d/create_table.sql
+++ b/db/initdb.d/create_table.sql
@@ -7,8 +7,8 @@ CREATE TABLE `member` (
                           `password`	        varchar(100)  NOT NULL,
                           `email`     	    varchar(100)  NULL	COMMENT '이메일 주소',
                           `hp_no`	            varchar(100)  NULL	COMMENT '핸드폰 번호',
-                          `created_dt`	    timestamp	  NULL	DEFAULT NOW()	COMMENT '회원 생성일시',
-                          `updated_dt`	    timestamp	  NULL	COMMENT '회원 수정일시',
+                          `created_dt`	    timestamp(9)	  NULL	DEFAULT NOW()	COMMENT '회원 생성일시',
+                          `updated_dt`	    timestamp(9)	  NULL	COMMENT '회원 수정일시',
                           `use_yn`	        char(1)	      NULL DEFAULT 'Y'	COMMENT '회원 삭제 구분'
 );
 
@@ -20,8 +20,8 @@ CREATE TABLE `performance` (
                                `name`	            varchar(500)  NULL	COMMENT '공연 이름',
                                `place`	            varchar(500)  NULL    COMMENT '공연 장소',
                                `start_dt`	        timestamp	  NOT NULL    COMMENT '공연 시작 일시',
-                               `end_dt`	        timestamp	  NOT NULL    COMMENT '공연 종료 일시',
-                               `created_at`	    timestamp	  NULL	DEFAULT NOW()	COMMENT '공연정보 생성일시'
+                               `end_dt`	        timestamp(9)	  NOT NULL    COMMENT '공연 종료 일시',
+                               `created_at`	    timestamp(9)	  NULL	DEFAULT NOW()	COMMENT '공연정보 생성일시'
 );
 
 -- 공연자
@@ -29,17 +29,17 @@ DROP TABLE IF EXISTS `performer`;
 CREATE TABLE `performer` (
                              `performer_id`	    bigint	      NOT NULL AUTO_INCREMENT PRIMARY KEY	COMMENT '공연자 ID',
                              `name`	            varchar(300)  NOT NULL	COMMENT '공연자명',
-                             `performance_id`    bigint        NOT NULL	COMMENT '공연 ID'
+                             `performance_id`   bigint        NOT NULL	COMMENT '공연 ID'
 );
 
 -- 티켓 정보
 DROP TABLE IF EXISTS `ticket`;
 CREATE TABLE `ticket` (
                           `ticket_id`	        bigint	      NOT NULL AUTO_INCREMENT PRIMARY KEY	COMMENT '티켓 ID',
-                          `start_dt`	        timestamp	  NOT NULL	COMMENT '티켓 예매시작시간',
-                          `end_dt`	        timestamp	  NOT NULL	COMMENT '티켓 예매종료시간',
-                          `created_dt`	    timestamp     NULL DEFAULT NOW() COMMENT '티켓 생성일시',
-                          `performance_id`	bigint	      NOT NULL	COMMENT '공연 ID'
+                          `start_dt`	        timestamp(9)	  NOT NULL	COMMENT '티켓 예매시작시간',
+                          `end_dt`	            timestamp(9)	  NOT NULL	COMMENT '티켓 예매종료시간',
+                          `created_dt`	        timestamp(9)     NULL DEFAULT NOW() COMMENT '티켓 생성일시',
+                          `performance_id`	    bigint	      NOT NULL	COMMENT '공연 ID'
 );
 
 -- 티켓 등급
@@ -50,7 +50,8 @@ CREATE TABLE `ticket_grade` (
                                 `grade_name`	    varchar(20)	  NOT NULL	COMMENT '티켓 등급 명칭',
                                 `seat_count`        mediumint     NOT NULL	COMMENT '티켓 등급별 좌석 수',
                                 `price`             decimal(18,6) NOT NULL  COMMENT '티켓 가격',
-                                `created_dt`	    timestamp     NULL DEFAULT NOW() COMMENT '티켓 생성일시',
+                                `version`           int           DEFAULT 0 COMMENT '버전',
+                                `created_dt`	    timestamp(9)  NULL DEFAULT NOW() COMMENT '티켓 생성일시',
                                 `ticket_id`	        bigint	      NOT NULL	COMMENT '티켓 ID'
 );
 
@@ -62,5 +63,5 @@ CREATE TABLE `ticket_order` (
                                 `performance_id`    bigint        NOT NULL    COMMENT '공연 ID',
                                 `ticket_grade_id`   bigint        NOT NULL    COMMENT '티켓 등급 ID',
                                 `seat_info`         varchar(50)   NOT NULL    COMMENT '좌석정보',
-                                `created_dt`	    timestamp     NULL DEFAULT NOW() COMMENT '티켓 생성일시'
+                                `created_dt`	    timestamp(9)  NULL DEFAULT NOW() COMMENT '티켓 생성일시'
 );

--- a/src/main/java/com/ticketpark/common/repository/MariaDBNamedLockRepository.java
+++ b/src/main/java/com/ticketpark/common/repository/MariaDBNamedLockRepository.java
@@ -1,0 +1,21 @@
+package com.ticketpark.common.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MariaDBNamedLockRepository implements NameLockRepository {
+
+    private final NamedLockMapper namedLockMapper;
+
+    @Override
+    public Integer getLock(String lockName, int timeoutSeconds) {
+        return namedLockMapper.getLock(lockName, timeoutSeconds);
+    }
+
+    @Override
+    public Integer releaseLock(String lockName) {
+        return namedLockMapper.releaseLock(lockName);
+    }
+}

--- a/src/main/java/com/ticketpark/common/repository/NameLockRepository.java
+++ b/src/main/java/com/ticketpark/common/repository/NameLockRepository.java
@@ -1,0 +1,6 @@
+package com.ticketpark.common.repository;
+
+public interface NameLockRepository {
+    Integer getLock(String lockName, int timeoutSeconds);
+    Integer releaseLock(String lockName);
+}

--- a/src/main/java/com/ticketpark/common/repository/NamedLockMapper.java
+++ b/src/main/java/com/ticketpark/common/repository/NamedLockMapper.java
@@ -1,0 +1,9 @@
+package com.ticketpark.common.repository;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface NamedLockMapper {
+   Integer getLock(String lockName, int timeoutSeconds);
+   Integer releaseLock(String lockName);
+}

--- a/src/main/java/com/ticketpark/configuration/ConcurrencyControlConfig.java
+++ b/src/main/java/com/ticketpark/configuration/ConcurrencyControlConfig.java
@@ -1,0 +1,62 @@
+package com.ticketpark.configuration;
+
+import com.ticketpark.common.repository.MariaDBNamedLockRepository;
+import com.ticketpark.common.repository.NameLockRepository;
+import com.ticketpark.common.repository.NamedLockMapper;
+import com.ticketpark.ticket.repository.*;
+import com.ticketpark.ticket.service.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class ConcurrencyControlConfig {
+
+    @Autowired
+    private final TicketGradeMapper ticketGradeMapper;
+
+    @Autowired
+    private final TicketOrderMapper ticketOrderMapper;
+
+    @Autowired
+    private final NamedLockMapper nameLockMapper;
+
+    @Bean
+    public TicketOrderFacade ticketOrderFacade(){
+        return new TicketOrderFacadeByPessimisticLock(ticketGradeService(), ticketOrderService());
+        //return new TicketOrderFacadeByOptimisticLock(ticketGradeService(), ticketOrderService());
+        //return new TicketOrderFacadeByNamedLock(nameLockRepository(), ticketGradeService(), ticketOrderService());
+    }
+
+    @Bean
+    public TicketGradeService ticketGradeService(){
+        return new TicketGradeServiceByPessimisticLock(ticketGradeRepository());
+        //return new TicketGradeServiceByOptimisticLock(ticketGradeRepository());
+        //return new TicketGradeServiceByNamedLock(ticketGradeRepository());
+    }
+
+    @Bean
+    public TicketOrderService ticketOrderService(){
+        return new TicketOrderServiceByPessimisticLock(ticketOrderRepository(), ticketGradeRepository());
+        //return new TicketOrderServiceByOptimisticLock(ticketOrderRepository(), ticketGradeRepository());
+        //return new TicketOrderServiceByNamedLock(ticketOrderRepository(), ticketGradeRepository());
+    }
+
+    @Bean
+    public NameLockRepository nameLockRepository(){
+        return new MariaDBNamedLockRepository(nameLockMapper);
+    }
+
+    @Bean
+    public TicketGradeRepository ticketGradeRepository(){
+        return new MybatisTicketGradeRepository(ticketGradeMapper);
+    }
+
+    @Bean
+    public TicketOrderRepository ticketOrderRepository(){
+        return new MyBatisTicketOrderRepository(ticketOrderMapper);
+    }
+
+}

--- a/src/main/java/com/ticketpark/member/repository/MemberMapper.java
+++ b/src/main/java/com/ticketpark/member/repository/MemberMapper.java
@@ -17,4 +17,6 @@ public interface MemberMapper {
 
     //회원 삭제
     int deleteMember(String id);
+
+    void deleteAllMember();
 }

--- a/src/main/java/com/ticketpark/member/repository/MemberRepository.java
+++ b/src/main/java/com/ticketpark/member/repository/MemberRepository.java
@@ -12,4 +12,6 @@ public interface MemberRepository {
     Optional<Member> findById(String id);
 
     int deleteMember(String id);
+
+    void deleteAllMember();
 }

--- a/src/main/java/com/ticketpark/member/repository/MyBatisMemberRepository.java
+++ b/src/main/java/com/ticketpark/member/repository/MyBatisMemberRepository.java
@@ -25,4 +25,9 @@ public class MyBatisMemberRepository implements MemberRepository {
     public int deleteMember(String id) {
         return memberMapper.deleteMember(id);
     }
+
+    @Override
+    public void deleteAllMember() {
+        memberMapper.deleteAllMember();
+    }
 }

--- a/src/main/java/com/ticketpark/performance/repository/MybatisPerformanceRepository.java
+++ b/src/main/java/com/ticketpark/performance/repository/MybatisPerformanceRepository.java
@@ -15,4 +15,14 @@ public class MybatisPerformanceRepository implements PerformanceRepository {
     public void createPerformance(Performance performance) {
         performanceMapper.createPerformance(performance);
     }
+
+    @Override
+    public int deletePerformance(Long performanceId) {
+        return performanceMapper.deletePerformance(performanceId);
+    }
+
+    @Override
+    public void deleteAllPerformance() {
+        performanceMapper.deleteAllPerformance();
+    }
 }

--- a/src/main/java/com/ticketpark/performance/repository/MybatisPerformerRepository.java
+++ b/src/main/java/com/ticketpark/performance/repository/MybatisPerformerRepository.java
@@ -16,4 +16,9 @@ public class MybatisPerformerRepository implements PerformerRepository{
     public void createPerformer(List<Performer> performers) {
         performerMapper.createPerformer(performers);
     }
+
+    @Override
+    public void deleteAllPerformer() {
+        performerMapper.deleteAllPerformer();
+    }
 }

--- a/src/main/java/com/ticketpark/performance/repository/PerformanceMapper.java
+++ b/src/main/java/com/ticketpark/performance/repository/PerformanceMapper.java
@@ -7,4 +7,8 @@ import org.apache.ibatis.annotations.Param;
 @Mapper
 public interface PerformanceMapper {
     void createPerformance(@Param("performance") Performance performance);
+
+    int deletePerformance(Long performanceId);
+
+    void deleteAllPerformance();
 }

--- a/src/main/java/com/ticketpark/performance/repository/PerformanceRepository.java
+++ b/src/main/java/com/ticketpark/performance/repository/PerformanceRepository.java
@@ -4,4 +4,6 @@ import com.ticketpark.performance.model.entity.Performance;
 
 public interface PerformanceRepository {
     void createPerformance(Performance performance);
+    int deletePerformance(Long performanceId);
+    void deleteAllPerformance();
 }

--- a/src/main/java/com/ticketpark/performance/repository/PerformerMapper.java
+++ b/src/main/java/com/ticketpark/performance/repository/PerformerMapper.java
@@ -9,4 +9,6 @@ import java.util.List;
 @Mapper
 public interface PerformerMapper {
     void createPerformer(List<Performer> performers);
+    Long deletePerfomerByPerformanceId(Long performanceId);
+    void deleteAllPerformer();
 }

--- a/src/main/java/com/ticketpark/performance/repository/PerformerRepository.java
+++ b/src/main/java/com/ticketpark/performance/repository/PerformerRepository.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface PerformerRepository {
     void createPerformer(List<Performer> performers);
+    void deleteAllPerformer();
 }

--- a/src/main/java/com/ticketpark/ticket/repository/MyBatisTicketOrderRepository.java
+++ b/src/main/java/com/ticketpark/ticket/repository/MyBatisTicketOrderRepository.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
-@Repository
+//@Repository
 @RequiredArgsConstructor
 public class MyBatisTicketOrderRepository implements TicketOrderRepository {
 
@@ -23,7 +23,19 @@ public class MyBatisTicketOrderRepository implements TicketOrderRepository {
     }
 
     @Override
+    public Optional<TicketOrder> getTickOrderBySeatInfoAndPessimisticLock(Long performanceId, Long ticketGradeId, String seatInfo) {
+        return ticketOrderMapper.getTickOrderBySeatInfoAndPessimisticLock(performanceId, ticketGradeId, seatInfo);
+    }
+
+    @Override
     public Optional<TicketOrder> getTickOrder(Long ticketOrderId) {
         return ticketOrderMapper.getTickOrder(ticketOrderId);
     }
+
+    @Override
+    public void deleteAllTicketOrder() {
+        ticketOrderMapper.deleteAllTicketOrder();
+    }
+
+
 }

--- a/src/main/java/com/ticketpark/ticket/repository/MybatisTicketGradeRepository.java
+++ b/src/main/java/com/ticketpark/ticket/repository/MybatisTicketGradeRepository.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
+//@Repository
 @RequiredArgsConstructor
 public class MybatisTicketGradeRepository implements TicketGradeRepository{
 
@@ -23,7 +23,29 @@ public class MybatisTicketGradeRepository implements TicketGradeRepository{
     }
 
     @Override
+    public Integer getCountTicketByGradeByPessimisticLock(Long ticketGradeId) {
+        return ticketGradeMapper.getCountTicketByGradeByPessimisticLock(ticketGradeId);
+    }
+
+    @Override
+    public TicketGrade getTicketGrade(Long ticketGradeId) {
+        return ticketGradeMapper.getTicketGrade(ticketGradeId);
+    }
+
+    @Override
+    public Integer updateSeatCountByByOptimisticLock(Long ticketGradeId, Long version) {
+        return ticketGradeMapper.updateSeatCountByByOptimisticLock(ticketGradeId, version);
+    }
+
+    @Override
     public Integer updateSeatCount(Long ticketGradeId) {
         return ticketGradeMapper.updateSeatCount(ticketGradeId);
+    }
+
+
+
+    @Override
+    public void deleteAllTicketGrade() {
+        ticketGradeMapper.deleteAllTicketGrade();
     }
 }

--- a/src/main/java/com/ticketpark/ticket/repository/MybatisTicketRepository.java
+++ b/src/main/java/com/ticketpark/ticket/repository/MybatisTicketRepository.java
@@ -14,4 +14,9 @@ public class MybatisTicketRepository implements TicketRepository{
     public void createTicket(Ticket ticket) {
         ticketMapper.createTicket(ticket);
     }
+
+    @Override
+    public void deleteAllTicket() {
+        ticketMapper.deleteAllTicket();
+    }
 }

--- a/src/main/java/com/ticketpark/ticket/repository/TicketGradeMapper.java
+++ b/src/main/java/com/ticketpark/ticket/repository/TicketGradeMapper.java
@@ -8,5 +8,9 @@ import java.util.List;
 public interface TicketGradeMapper {
     void createTicketGrade(List<TicketGrade> ticketGradeList);
     Integer getCountTicketGrade(Long ticketGradeId);
+    Integer getCountTicketByGradeByPessimisticLock(Long ticketGradeId);
+    TicketGrade getTicketGrade(Long ticketGradeId);
     Integer updateSeatCount(Long ticketGradeId);
+    Integer updateSeatCountByByOptimisticLock(Long ticketGradeId, Long version);
+    void deleteAllTicketGrade();
 }

--- a/src/main/java/com/ticketpark/ticket/repository/TicketGradeRepository.java
+++ b/src/main/java/com/ticketpark/ticket/repository/TicketGradeRepository.java
@@ -8,5 +8,13 @@ public interface TicketGradeRepository {
 
     Integer getCountTicketGrade(Long ticketGradeId);
 
+    Integer getCountTicketByGradeByPessimisticLock(Long ticketGradeId);
+
+    TicketGrade getTicketGrade(Long ticketGradeId);
+
     Integer updateSeatCount(Long ticketGradeId);
+
+    Integer updateSeatCountByByOptimisticLock(Long ticketGradeId, Long version);
+
+    void deleteAllTicketGrade();
 }

--- a/src/main/java/com/ticketpark/ticket/repository/TicketMapper.java
+++ b/src/main/java/com/ticketpark/ticket/repository/TicketMapper.java
@@ -7,5 +7,6 @@ import org.apache.ibatis.annotations.Param;
 @Mapper
 public interface TicketMapper {
     void createTicket(@Param("ticket") Ticket ticket);
+    void deleteAllTicket();
 }
 

--- a/src/main/java/com/ticketpark/ticket/repository/TicketOrderMapper.java
+++ b/src/main/java/com/ticketpark/ticket/repository/TicketOrderMapper.java
@@ -14,6 +14,14 @@ public interface TicketOrderMapper {
             , Long ticketGradeId
             ,  String seatInfo);
 
+    Optional<TicketOrder> getTickOrderBySeatInfoAndPessimisticLock(
+            Long performanceId
+            , Long ticketGradeId
+            ,  String seatInfo);
+
     Optional<TicketOrder> getTickOrder(Long ticketOrderId);
+
+
+    void deleteAllTicketOrder();
 
 }

--- a/src/main/java/com/ticketpark/ticket/repository/TicketOrderRepository.java
+++ b/src/main/java/com/ticketpark/ticket/repository/TicketOrderRepository.java
@@ -6,5 +6,8 @@ import java.util.Optional;
 public interface TicketOrderRepository {
     void createTicketOrder(TicketOrder ticketOrder);
     Optional<TicketOrder> getTickOrderBySeatInfo(Long performanceId, Long ticketGradeId, String seatInfo);
+    Optional<TicketOrder> getTickOrderBySeatInfoAndPessimisticLock(Long performanceId, Long ticketGradeId, String seatInfo);
+
     Optional<TicketOrder> getTickOrder(Long ticketOrderId);
+    void deleteAllTicketOrder();
 }

--- a/src/main/java/com/ticketpark/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/ticketpark/ticket/repository/TicketRepository.java
@@ -4,4 +4,5 @@ import com.ticketpark.ticket.model.entity.Ticket;
 
 public interface TicketRepository {
     void createTicket(Ticket ticket);
+    void deleteAllTicket();
 }

--- a/src/main/java/com/ticketpark/ticket/service/OptimisticLockRetry.java
+++ b/src/main/java/com/ticketpark/ticket/service/OptimisticLockRetry.java
@@ -1,0 +1,13 @@
+package com.ticketpark.ticket.service;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OptimisticLockRetry {
+    int value() default 10;
+}

--- a/src/main/java/com/ticketpark/ticket/service/OptimisticLockRetryAspect.java
+++ b/src/main/java/com/ticketpark/ticket/service/OptimisticLockRetryAspect.java
@@ -1,0 +1,35 @@
+package com.ticketpark.ticket.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class OptimisticLockRetryAspect {
+
+    @Value("${retry.optimisticLock.count}")
+    private byte retryCount;
+
+    @Around("@annotation(retry)")
+    public Object doRetry(ProceedingJoinPoint joinPoint, OptimisticLockRetry retry) throws Throwable {
+        RuntimeException exceptionHolder = null;
+        int maxRetry = retryCount > 0 ? retryCount : retry.value();
+
+        for (int retryCount = 1; retryCount <= maxRetry; retryCount++) {
+            try {
+                log.debug("[retry] try count {}/{}", retryCount, maxRetry);
+                return joinPoint.proceed();
+            } catch (OptimisticLockingFailureException e) {
+                log.debug("버전 충돌 발생 / 예매 retry start {}", joinPoint.getArgs());
+                exceptionHolder = e;
+            }
+        }
+        throw exceptionHolder;
+    }
+}

--- a/src/main/java/com/ticketpark/ticket/service/TicketGradeService.java
+++ b/src/main/java/com/ticketpark/ticket/service/TicketGradeService.java
@@ -1,26 +1,7 @@
 package com.ticketpark.ticket.service;
 
-import com.ticketpark.exception.ErrorCode;
-import com.ticketpark.exception.TicketParkException;
 import com.ticketpark.ticket.model.dto.TicketOrderDto;
-import com.ticketpark.ticket.repository.TicketGradeRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Service
-@RequiredArgsConstructor
-public class TicketGradeService {
-    private final TicketGradeRepository ticketGradeRepository;
-
-    @Transactional(readOnly = true)
-    public boolean isFullBooked(TicketOrderDto dto){
-        //해당 좌석 등급의 남아있는 티켓 매수 확인
-        Integer remainTicketCount = ticketGradeRepository.getCountTicketGrade(dto.getTicket_grade_id());
-        if(remainTicketCount<=0){
-            throw new TicketParkException(ErrorCode.ALL_BOOKED_TICKET
-                    , String.format("this ticket grade is all booked / ticket_grade_id : %s", dto.getTicket_grade_id()));
-        }
-        return true;
-    }
+public interface TicketGradeService {
+    public boolean isFullBooked(TicketOrderDto dto);
 }

--- a/src/main/java/com/ticketpark/ticket/service/TicketGradeServiceByNamedLock.java
+++ b/src/main/java/com/ticketpark/ticket/service/TicketGradeServiceByNamedLock.java
@@ -1,0 +1,25 @@
+package com.ticketpark.ticket.service;
+
+import com.ticketpark.exception.ErrorCode;
+import com.ticketpark.exception.TicketParkException;
+import com.ticketpark.ticket.model.dto.TicketOrderDto;
+import com.ticketpark.ticket.repository.TicketGradeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+//@Service
+@RequiredArgsConstructor
+public class TicketGradeServiceByNamedLock implements TicketGradeService {
+    private final TicketGradeRepository ticketGradeRepository;
+
+    @Transactional(readOnly = true)
+    public boolean isFullBooked(TicketOrderDto dto){
+        //해당 좌석 등급의 남아있는 티켓 매수 확인
+        Integer remainTicketCount = ticketGradeRepository.getCountTicketGrade(dto.getTicket_grade_id());
+        if(remainTicketCount<=0){
+            throw new TicketParkException(ErrorCode.ALL_BOOKED_TICKET
+                    , String.format("this ticket grade is all booked / ticket_grade_id : %s", dto.getTicket_grade_id()));
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/ticketpark/ticket/service/TicketGradeServiceByOptimisticLock.java
+++ b/src/main/java/com/ticketpark/ticket/service/TicketGradeServiceByOptimisticLock.java
@@ -1,0 +1,27 @@
+package com.ticketpark.ticket.service;
+
+import com.ticketpark.exception.ErrorCode;
+import com.ticketpark.exception.TicketParkException;
+import com.ticketpark.ticket.model.dto.TicketOrderDto;
+import com.ticketpark.ticket.repository.TicketGradeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+//@Service
+@Slf4j
+@RequiredArgsConstructor
+public class TicketGradeServiceByOptimisticLock implements TicketGradeService {
+    private final TicketGradeRepository ticketGradeRepository;
+
+    public boolean isFullBooked(TicketOrderDto dto){
+        log.debug("1. 해당 등급 예매 전부 됐는지 확인 조회 / 좌석등급={}", dto.getTicket_grade_id());
+
+        //해당 좌석 등급의 남아있는 티켓 매수 확인
+        Integer remainTicketCount = ticketGradeRepository.getCountTicketGrade(dto.getTicket_grade_id());
+        if(remainTicketCount<=0){
+            throw new TicketParkException(ErrorCode.ALL_BOOKED_TICKET
+                    , String.format("this ticket grade is all booked / ticket_grade_id : %s", dto.getTicket_grade_id()));
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/ticketpark/ticket/service/TicketGradeServiceByPessimisticLock.java
+++ b/src/main/java/com/ticketpark/ticket/service/TicketGradeServiceByPessimisticLock.java
@@ -1,0 +1,25 @@
+package com.ticketpark.ticket.service;
+
+import com.ticketpark.exception.ErrorCode;
+import com.ticketpark.exception.TicketParkException;
+import com.ticketpark.ticket.model.dto.TicketOrderDto;
+import com.ticketpark.ticket.repository.TicketGradeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+//@Service
+@RequiredArgsConstructor
+public class TicketGradeServiceByPessimisticLock implements TicketGradeService {
+    private final TicketGradeRepository ticketGradeRepository;
+
+    @Transactional(readOnly = true)
+    public boolean isFullBooked(TicketOrderDto dto){
+        //해당 좌석 등급의 남아있는 티켓 매수 확인
+        Integer remainTicketCount = ticketGradeRepository.getCountTicketByGradeByPessimisticLock(dto.getTicket_grade_id());
+        if(remainTicketCount<=0){
+            throw new TicketParkException(ErrorCode.ALL_BOOKED_TICKET
+                    , String.format("this ticket grade is all booked / ticket_grade_id : %s", dto.getTicket_grade_id()));
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/ticketpark/ticket/service/TicketOrderFacade.java
+++ b/src/main/java/com/ticketpark/ticket/service/TicketOrderFacade.java
@@ -2,28 +2,7 @@ package com.ticketpark.ticket.service;
 
 import com.ticketpark.ticket.model.dto.TicketOrderDto;
 import com.ticketpark.ticket.model.entity.TicketOrder;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
-@Component
-@RequiredArgsConstructor
-public class TicketOrderFacade {
-
-    private final TicketGradeService ticketGradeService;
-    private final TicketOrderService ticketOrderService;
-
-    @Transactional
-    public TicketOrder orderTicket(TicketOrderDto orderDto){
-        ticketGradeService.isFullBooked(orderDto);
-        ticketOrderService.checkBookableTicket(orderDto);
-        return saveTicketOrder(orderDto);
-    }
-
-    private TicketOrder saveTicketOrder(TicketOrderDto orderDto){
-        return ticketOrderService.saveTicketOrder(orderDto);
-    }
-
+public interface TicketOrderFacade{
+    public TicketOrder orderTicket(TicketOrderDto orderDto);
 }

--- a/src/main/java/com/ticketpark/ticket/service/TicketOrderFacadeByNamedLock.java
+++ b/src/main/java/com/ticketpark/ticket/service/TicketOrderFacadeByNamedLock.java
@@ -1,0 +1,34 @@
+package com.ticketpark.ticket.service;
+
+import com.ticketpark.common.repository.NameLockRepository;
+import com.ticketpark.ticket.model.dto.TicketOrderDto;
+import com.ticketpark.ticket.model.entity.TicketOrder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+public class TicketOrderFacadeByNamedLock implements TicketOrderFacade {
+
+    private final NameLockRepository nameLockRepository;
+    private final TicketGradeService ticketGradeService;
+    private final TicketOrderService ticketOrderService;
+
+    @Transactional
+    public TicketOrder orderTicket(TicketOrderDto orderDto){
+        TicketOrder orderResult;
+        try{
+            nameLockRepository.getLock("ticket_order", 300);
+            ticketGradeService.isFullBooked(orderDto);
+            ticketOrderService.checkBookableTicket(orderDto);
+            orderResult = saveTicketOrder(orderDto);
+        }finally {
+            nameLockRepository.releaseLock("ticket_order");
+        }
+        return orderResult;
+    }
+
+    private TicketOrder saveTicketOrder(TicketOrderDto orderDto){
+        return ticketOrderService.saveTicketOrder(orderDto);
+    }
+
+}

--- a/src/main/java/com/ticketpark/ticket/service/TicketOrderFacadeByOptimisticLock.java
+++ b/src/main/java/com/ticketpark/ticket/service/TicketOrderFacadeByOptimisticLock.java
@@ -1,0 +1,24 @@
+package com.ticketpark.ticket.service;
+
+import com.ticketpark.ticket.model.dto.TicketOrderDto;
+import com.ticketpark.ticket.model.entity.TicketOrder;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TicketOrderFacadeByOptimisticLock implements TicketOrderFacade {
+
+    private final TicketGradeService ticketGradeService;
+    private final TicketOrderService ticketOrderService;
+
+    @OptimisticLockRetry
+    public TicketOrder orderTicket(TicketOrderDto orderDto){
+        ticketGradeService.isFullBooked(orderDto);
+        ticketOrderService.checkBookableTicket(orderDto);
+        return saveTicketOrder(orderDto);
+    }
+
+    private TicketOrder saveTicketOrder(TicketOrderDto orderDto){
+        return ticketOrderService.saveTicketOrder(orderDto);
+    }
+
+}

--- a/src/main/java/com/ticketpark/ticket/service/TicketOrderFacadeByPessimisticLock.java
+++ b/src/main/java/com/ticketpark/ticket/service/TicketOrderFacadeByPessimisticLock.java
@@ -1,0 +1,26 @@
+package com.ticketpark.ticket.service;
+
+import com.ticketpark.ticket.model.dto.TicketOrderDto;
+import com.ticketpark.ticket.model.entity.TicketOrder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+public class TicketOrderFacadeByPessimisticLock implements TicketOrderFacade{
+
+    private final TicketGradeService ticketGradeService;
+    private final TicketOrderService ticketOrderService;
+
+    @Transactional
+    public TicketOrder orderTicket(TicketOrderDto orderDto){
+        ticketGradeService.isFullBooked(orderDto);
+        ticketOrderService.checkBookableTicket(orderDto);
+        return saveTicketOrder(orderDto);
+    }
+
+    private TicketOrder saveTicketOrder(TicketOrderDto orderDto){
+        return ticketOrderService.saveTicketOrder(orderDto);
+    }
+
+}

--- a/src/main/java/com/ticketpark/ticket/service/TicketOrderService.java
+++ b/src/main/java/com/ticketpark/ticket/service/TicketOrderService.java
@@ -8,37 +8,10 @@ import com.ticketpark.ticket.repository.TicketGradeRepository;
 import com.ticketpark.ticket.repository.TicketOrderRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
-@RequiredArgsConstructor
-public class TicketOrderService {
-
-    private final TicketOrderRepository ticketOrderRepository;
-    private final TicketGradeRepository ticketGradeRepository;
-
-    @Transactional(readOnly = true)
-    public void checkBookableTicket(TicketOrderDto orderDto){
-        //내가 선택한 좌석이 예매됐는지 확인
-        ticketOrderRepository.getTickOrderBySeatInfo(orderDto.getPerformance_id()
-                        , orderDto.getTicket_grade_id()
-                        , orderDto.getSeat_info())
-                .ifPresent(t -> {
-                    throw new TicketParkException(ErrorCode.BOOKED_TICKET
-                            , String.format("this ticket order already booked / ticket_grade_id : %s, seat_info : %s"
-                            , orderDto.getTicket_grade_id()
-                            , orderDto.getSeat_info()));
-                });
-    }
-
-    @Transactional
-    public TicketOrder saveTicketOrder(TicketOrderDto orderDto){
-        //좌석 수 감소
-        ticketGradeRepository.updateSeatCount(orderDto.getPerformance_id());
-        //티켓 주문 insert
-        TicketOrder ticketOrder = orderDto.getEntity();
-        ticketOrderRepository.createTicketOrder(ticketOrder);
-
-        return ticketOrder;
-    }
+public interface TicketOrderService {
+    public void checkBookableTicket(TicketOrderDto orderDto);
+    public TicketOrder saveTicketOrder(TicketOrderDto orderDto);
 }

--- a/src/main/java/com/ticketpark/ticket/service/TicketOrderServiceByNamedLock.java
+++ b/src/main/java/com/ticketpark/ticket/service/TicketOrderServiceByNamedLock.java
@@ -1,0 +1,48 @@
+package com.ticketpark.ticket.service;
+
+import com.ticketpark.exception.ErrorCode;
+import com.ticketpark.exception.TicketParkException;
+import com.ticketpark.ticket.model.dto.TicketOrderDto;
+import com.ticketpark.ticket.model.entity.TicketGrade;
+import com.ticketpark.ticket.model.entity.TicketOrder;
+import com.ticketpark.ticket.repository.TicketGradeRepository;
+import com.ticketpark.ticket.repository.TicketOrderRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+//@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TicketOrderServiceByNamedLock implements TicketOrderService {
+
+    private final TicketOrderRepository ticketOrderRepository;
+    private final TicketGradeRepository ticketGradeRepository;
+
+    @Transactional(readOnly = true)
+    public void checkBookableTicket(TicketOrderDto orderDto){
+        //내가 선택한 좌석이 예매됐는지 확인
+        ticketOrderRepository.getTickOrderBySeatInfo(orderDto.getPerformance_id()
+                        , orderDto.getTicket_grade_id()
+                        , orderDto.getSeat_info())
+                .ifPresent(t -> {
+                    throw new TicketParkException(ErrorCode.BOOKED_TICKET
+                            , String.format("this ticket order already booked / ticket_grade_id : %s, seat_info : %s"
+                            , orderDto.getTicket_grade_id()
+                            , orderDto.getSeat_info()));
+                });
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public TicketOrder saveTicketOrder(TicketOrderDto orderDto){
+        //좌석 수 감소
+        ticketGradeRepository.updateSeatCount(orderDto.getPerformance_id());
+        //티켓 주문 insert
+        TicketOrder ticketOrder = orderDto.getEntity();
+        ticketOrderRepository.createTicketOrder(ticketOrder);
+
+        return ticketOrder;
+    }
+
+}

--- a/src/main/java/com/ticketpark/ticket/service/TicketOrderServiceByOptimisticLock.java
+++ b/src/main/java/com/ticketpark/ticket/service/TicketOrderServiceByOptimisticLock.java
@@ -1,0 +1,87 @@
+package com.ticketpark.ticket.service;
+
+import com.ticketpark.exception.ErrorCode;
+import com.ticketpark.exception.TicketParkException;
+import com.ticketpark.ticket.model.dto.TicketOrderDto;
+import com.ticketpark.ticket.model.entity.TicketGrade;
+import com.ticketpark.ticket.model.entity.TicketOrder;
+import com.ticketpark.ticket.repository.TicketGradeRepository;
+import com.ticketpark.ticket.repository.TicketOrderRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+import java.util.Optional;
+
+//@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TicketOrderServiceByOptimisticLock implements TicketOrderService {
+
+    private final TicketOrderRepository ticketOrderRepository;
+    private final TicketGradeRepository ticketGradeRepository;
+
+    public void checkBookableTicket(TicketOrderDto orderDto){
+        log.debug("2. 내가 선택한 좌석 예매됐는지 확인 / 좌석 등급={}, 좌석정보={}"
+                , orderDto.getTicket_grade_id()
+                ,orderDto.getSeat_info());
+
+        //내가 선택한 좌석이 예매됐는지 확인
+        ticketOrderRepository.getTickOrderBySeatInfo(orderDto.getPerformance_id()
+                        , orderDto.getTicket_grade_id()
+                        , orderDto.getSeat_info())
+                .ifPresent(t -> {
+                    throw new TicketParkException(ErrorCode.BOOKED_TICKET
+                            , String.format("this ticket order already booked / ticket_grade_id : %s, seat_info : %s"
+                            , orderDto.getTicket_grade_id()
+                            , orderDto.getSeat_info()));
+                });
+    }
+
+
+    public TicketOrder saveTicketOrder(TicketOrderDto orderDto){
+
+        TicketGrade ticketGradeInfo = validateTicketGrade(orderDto);
+
+        //좌석 수 감소
+        //update row 없으면 낙관적 락 exception
+        Integer rowCnt = ticketGradeRepository.updateSeatCountByByOptimisticLock(
+                ticketGradeInfo.getTicket_grade_id()
+                , ticketGradeInfo.getVersion());
+
+        if(rowCnt == 0){
+            throw new OptimisticLockingFailureException("낙관적 락 발생");
+        }
+        log.debug("4. 해당 등급 좌석 수 감소 완료 / 좌석 등급 정보={}", orderDto.getTicket_grade_id());
+
+        //티켓 주문 insert
+        TicketOrder ticketOrder = orderDto.getEntity();
+        ticketOrderRepository.createTicketOrder(ticketOrder);
+        log.debug("5. 티켓 예매 정상 완료 / 좌석 등급={}, 좌석 정보={}"
+                ,orderDto.getTicket_grade_id()
+                , orderDto.getSeat_info());
+
+
+        return ticketOrder;
+    }
+
+    private TicketGrade validateTicketGrade(TicketOrderDto orderDto){
+        //좌석 정보 조회
+        TicketGrade ticketGradeInfo = ticketGradeRepository.getTicketGrade(orderDto.getTicket_grade_id());
+        log.debug("3. 예매 시작 / 현재 좌석 수 = {}", ticketGradeInfo.getSeat_count());
+
+        if(ticketGradeInfo.getSeat_count() <= 0){
+            log.debug("3 error 좌석 수 0이라서 예매 불가!!!!!!!");
+            throw new TicketParkException(ErrorCode.ALL_BOOKED_TICKET
+                    , String.format("this ticket grade is all booked / ticket_grade_id : %s", orderDto.getTicket_grade_id()));
+        }
+
+        return ticketGradeInfo;
+    }
+
+
+}

--- a/src/main/java/com/ticketpark/ticket/service/TicketOrderServiceByPessimisticLock.java
+++ b/src/main/java/com/ticketpark/ticket/service/TicketOrderServiceByPessimisticLock.java
@@ -1,0 +1,44 @@
+package com.ticketpark.ticket.service;
+
+import com.ticketpark.exception.ErrorCode;
+import com.ticketpark.exception.TicketParkException;
+import com.ticketpark.ticket.model.dto.TicketOrderDto;
+import com.ticketpark.ticket.model.entity.TicketOrder;
+import com.ticketpark.ticket.repository.TicketGradeRepository;
+import com.ticketpark.ticket.repository.TicketOrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+//@Service
+@RequiredArgsConstructor
+public class TicketOrderServiceByPessimisticLock implements TicketOrderService {
+
+    private final TicketOrderRepository ticketOrderRepository;
+    private final TicketGradeRepository ticketGradeRepository;
+
+    @Transactional(readOnly = true)
+    public void checkBookableTicket(TicketOrderDto orderDto){
+        //내가 선택한 좌석이 예매됐는지 확인
+        ticketOrderRepository.getTickOrderBySeatInfoAndPessimisticLock(orderDto.getPerformance_id()
+                        , orderDto.getTicket_grade_id()
+                        , orderDto.getSeat_info())
+                .ifPresent(t -> {
+                    throw new TicketParkException(ErrorCode.BOOKED_TICKET
+                            , String.format("this ticket order already booked / ticket_grade_id : %s, seat_info : %s"
+                            , orderDto.getTicket_grade_id()
+                            , orderDto.getSeat_info()));
+                });
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public TicketOrder saveTicketOrder(TicketOrderDto orderDto){
+        //좌석 수 감소
+        ticketGradeRepository.updateSeatCount(orderDto.getPerformance_id());
+        //티켓 주문 insert
+        TicketOrder ticketOrder = orderDto.getEntity();
+        ticketOrderRepository.createTicketOrder(ticketOrder);
+
+        return ticketOrder;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,9 @@ logging:
         jdbc:
           datasource:
             DataSourceTransactionManager : debug
+retry:
+  optimisticLock:
+    count: 5
+
+
+

--- a/src/main/resources/mapper/LockMapper.xml
+++ b/src/main/resources/mapper/LockMapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.ticketpark.common.repository.NamedLockMapper">
+    <select id="getLock" resultType="Integer">
+        select get_lock(#{lockName}, #{timeoutSeconds})
+    </select>
+
+    <select id="releaseLock" resultType="Integer">
+        select release_lock(#{lockName})
+    </select>
+</mapper>

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -35,5 +35,9 @@
         delete from member where id = #{id}
     </delete>
 
+    <delete id="deleteAllMember">
+        truncate table member
+    </delete>
+
 
 </mapper>

--- a/src/main/resources/mapper/PerformanceMapper.xml
+++ b/src/main/resources/mapper/PerformanceMapper.xml
@@ -14,4 +14,8 @@
               , #{performance.created_at}
               )
     </insert>
+
+    <delete id="deleteAllPerformance">
+        truncate table performance
+    </delete>
 </mapper>

--- a/src/main/resources/mapper/PerformerMapper.xml
+++ b/src/main/resources/mapper/PerformerMapper.xml
@@ -12,4 +12,8 @@
             )
         </foreach>
     </insert>
+
+    <delete id="deleteAllPerformer">
+        truncate table performer
+    </delete>
 </mapper>

--- a/src/main/resources/mapper/TicketGradeMapper.xml
+++ b/src/main/resources/mapper/TicketGradeMapper.xml
@@ -17,28 +17,51 @@
         </foreach>
     </insert>
 
-    <delete id="deleteMember" parameterType="String">
-        delete from member where id = #{id}
-    </delete>
-
     <select id="getCountTicketGrade" parameterType="Long">
         select
             seat_count
         from ticket_grade
-        where ticket_grade_id = #{ticket_grade_id}
+        where ticket_grade_id = #{ticketGradeId}
     </select>
 
-    <select id="getCountTicketGradeByPessimisticLock" parameterType="Long">
+    <select id="getTicketGrade" resultType="com.ticketpark.ticket.model.entity.TicketGrade">
+        select
+            ticket_grade_id
+            , grade
+            , grade_name
+            , seat_count
+            , price
+            , created_dt
+            , ticket_id
+            , version
+        from ticket_grade
+        where ticket_grade_id = #{ticketGradeId}
+    </select>
+
+    <select id="getCountTicketByGradeByPessimisticLock" parameterType="Long">
         select
             seat_count
         from ticket_grade
-        where ticket_grade_id = #{ticket_grade_id}
+        where ticket_grade_id = #{ticketGradeId}
         for update
     </select>
 
     <update id="updateSeatCount">
         update ticket_grade
-            set seat_count = seat_count-1
-        where ticket_grade_id = #{ticket_grade_id}
+        set seat_count = seat_count - 1
+        where ticket_grade_id = #{ticketGradeId}
     </update>
+
+    <update id="updateSeatCountByByOptimisticLock">
+        update ticket_grade
+        set seat_count = seat_count - 1
+            , version = version + 1
+        where ticket_grade_id = #{ticketGradeId}
+          and version = #{version}
+    </update>
+
+    <delete id="deleteAllTicketGrade">
+        truncate table ticket_grade
+    </delete>
+
 </mapper>

--- a/src/main/resources/mapper/TicketMapper.xml
+++ b/src/main/resources/mapper/TicketMapper.xml
@@ -11,4 +11,8 @@
               , #{ticket.created_dt}
               , #{ticket.performance_id})
     </insert>
+
+    <delete id="deleteAllTicket">
+        truncate table ticket
+    </delete>
 </mapper>

--- a/src/main/resources/mapper/TicketOrderMapper.xml
+++ b/src/main/resources/mapper/TicketOrderMapper.xml
@@ -28,6 +28,21 @@
             and seat_info = #{seatInfo}
     </select>
 
+    <select id="getTickOrderBySeatInfoAndPessimisticLock" resultType="com.ticketpark.ticket.model.entity.TicketOrder">
+        select
+            ticket_order_id
+             ,member_id
+             ,performance_id
+             ,ticket_grade_id
+             ,seat_info
+             ,created_dt
+        from ticket_order
+        where performance_id = #{performanceId}
+          and ticket_grade_id = #{ticketGradeId}
+          and seat_info = #{seatInfo}
+            for update
+    </select>
+
     <select id="getTickOrder" resultType="com.ticketpark.ticket.model.entity.TicketOrder">
         select
             ticket_order_id
@@ -37,6 +52,10 @@
              ,seat_info
              ,created_dt
         from ticket_order
-        where ticket_order_id = #{ticket_order_id}
+        where ticket_order_id = #{ticketOrderId}
     </select>
+
+    <delete id="deleteAllTicketOrder">
+        truncate table ticket_order
+    </delete>
 </mapper>

--- a/src/test/java/com/ticketpark/common/TestDataCleaner.java
+++ b/src/test/java/com/ticketpark/common/TestDataCleaner.java
@@ -1,0 +1,46 @@
+package com.ticketpark.common;
+
+import com.ticketpark.member.repository.MemberRepository;
+import com.ticketpark.performance.repository.PerformanceRepository;
+import com.ticketpark.performance.repository.PerformerRepository;
+import com.ticketpark.ticket.repository.TicketGradeRepository;
+import com.ticketpark.ticket.repository.TicketOrderRepository;
+import com.ticketpark.ticket.repository.TicketRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class TestDataCleaner {
+
+    //region [private]
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PerformanceRepository performanceRepository;
+
+    @Autowired
+    private PerformerRepository performerRepository;
+
+    @Autowired
+    private TicketRepository ticketRepository;
+
+    @Autowired
+    private TicketGradeRepository ticketGradeRepository;
+
+    @Autowired
+    private TicketOrderRepository ticketOrderRepository;
+    //endregion
+
+    @Transactional
+    public void cleanAll() {
+
+        memberRepository.deleteAllMember();
+        performanceRepository.deleteAllPerformance();
+        performerRepository.deleteAllPerformer();
+        ticketRepository.deleteAllTicket();
+        ticketGradeRepository.deleteAllTicketGrade();
+        ticketOrderRepository.deleteAllTicketOrder();
+    }
+}

--- a/src/test/java/com/ticketpark/ticket/fixture/TicketGradeFixture.java
+++ b/src/test/java/com/ticketpark/ticket/fixture/TicketGradeFixture.java
@@ -10,9 +10,9 @@ public class TicketGradeFixture {
 
     public static List<TicketGradeDto> getLitTicketGradeDto() {
         return Arrays.asList(
-                new TicketGradeDto("VIP", "VIP석", 200, 200000.0, LocalDateTime.now())
-                ,new TicketGradeDto("R", "R석", 200, 170000.0, LocalDateTime.now())
-                ,new TicketGradeDto("S", "S석", 200, 150000.0, LocalDateTime.now())
+                new TicketGradeDto("VIP", "VIP석", 100, 200000.0, LocalDateTime.now())
+                ,new TicketGradeDto("R", "R석", 100, 170000.0, LocalDateTime.now())
+                ,new TicketGradeDto("S", "S석", 100, 150000.0, LocalDateTime.now())
         );
     }
 }

--- a/src/test/java/com/ticketpark/ticket/fixture/TicketOrderFixture.java
+++ b/src/test/java/com/ticketpark/ticket/fixture/TicketOrderFixture.java
@@ -18,12 +18,12 @@ public class TicketOrderFixture {
                 .build();
     }
 
-    public static TicketOrderDto getTicketOrderDto(String seat_info) {
+    public static TicketOrderDto getTicketOrderDto(String seatInfo) {
         return TicketOrderDto.builder()
                 .member_id(TestConstants.defaultMemberId)
                 .performance_id(TestConstants.defaultPerformanceId)
                 .ticket_grade_id(TestConstants.defaultTicketGradeId)
-                .seat_info(seat_info)
+                .seat_info(seatInfo)
                 .created_dt(LocalDateTime.now())
                 .build();
     }

--- a/src/test/java/com/ticketpark/ticket/service/TicketOrderMultiThreadTest.java
+++ b/src/test/java/com/ticketpark/ticket/service/TicketOrderMultiThreadTest.java
@@ -1,28 +1,36 @@
 package com.ticketpark.ticket.service;
 
-import ch.qos.logback.core.testUtil.RandomUtil;
+import com.ticketpark.common.TestConstants;
+import com.ticketpark.common.TestDataCleaner;
+import com.ticketpark.performance.fixture.PerformanceRequestFixture;
+import com.ticketpark.performance.service.PerformanceService;
 import com.ticketpark.ticket.model.dto.TicketOrderDto;
 import com.ticketpark.ticket.repository.TicketGradeRepository;
-import com.ticketpark.ticket.fixture.TicketOrderFixture;
+import lombok.extern.slf4j.Slf4j;
 import net.bytebuddy.utility.RandomString;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-import java.util.Random;
+import java.time.LocalDateTime;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
-@Transactional
+@Slf4j
 public class TicketOrderMultiThreadTest {
+
+    //region [테스트 데이터 셋팅 위한 필드]
+    @Autowired
+    private PerformanceService  performanceService;
+
+    @Autowired
+    private TestDataCleaner testDataUtil;
+    //endregion
 
     @Autowired
     private TicketGradeRepository ticketGradeRepository;
@@ -31,6 +39,16 @@ public class TicketOrderMultiThreadTest {
     private TicketOrderFacade ticketOrderFacade;
 
     private TicketOrderDto ticketOrderDto;
+
+    @BeforeEach
+    void setup() {
+        /*------------------------------------------------
+        멀티스레드 테스트는 롤백테스트 적용 안되는 문제가 있어서
+        별도의 테스트 데이터 생성 및 제거가 필요함
+        ------------------------------------------------*/
+        //공연, 티켓, 티켓 등급 테스트 데이터 생성
+        performanceService.create(PerformanceRequestFixture.getPerformanceCreateRequest());
+    }
 
     @DisplayName("티켓 수 이상 예매요청이 들어오면 남아있는 티켓 수는 0이어야 한다")
     @Test
@@ -48,10 +66,14 @@ public class TicketOrderMultiThreadTest {
         for (int i = 0; i < threadCount; i++) {
             executorService.submit(()->{
                 try{
-                    String ranDomSeat = String.format("1층-A구역-%s",RandomString.make(4));
-                    ticketOrderDto = TicketOrderFixture.getTicketOrderDto(ranDomSeat);
+                    boolean isActiveTran = TransactionSynchronizationManager.isActualTransactionActive();
+                    String ranDomSeat = String.format("1층-A구역-%s", RandomString.make(4));
+                    ticketOrderDto = getTicketOrderDto(
+                            TestConstants.defaultPerformanceId + 1
+                            , TestConstants.defaultTicketGradeId + 1
+                            , ranDomSeat);
                     ticketOrderFacade.orderTicket(ticketOrderDto);
-                }finally {
+                } finally {
                     latch.countDown();
                 }
 
@@ -61,9 +83,24 @@ public class TicketOrderMultiThreadTest {
 
         //then
         int remainTicketCnt = ticketGradeRepository.getCountTicketGrade(ticketOrderDto.getTicket_grade_id());
-        //남아있는 티켓이 0미만이라 동시성 이슈 발생
-        assertNotEquals(0, remainTicketCnt);
         //TODO 아래 단언문 성공하도록 변경
-        //assertEquals(0, remainTicketCnt);
+        assertEquals(0, remainTicketCnt);
     }
+
+    //티켓 요청 Dto request
+    private TicketOrderDto getTicketOrderDto(Long performanceId, Long ticketGradeId, String seatInfo) {
+        return TicketOrderDto.builder()
+                .member_id(TestConstants.defaultMemberId)
+                .performance_id(performanceId)
+                .ticket_grade_id(ticketGradeId)
+                .seat_info(seatInfo)
+                .created_dt(LocalDateTime.now())
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        testDataUtil.cleanAll();
+    }
+
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,28 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    username: sa
+    url: jdbc:h2:mem:test;MODE=MariaDB;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE
+    password:
+  sql:
+    init:
+      mode: always
+  h2:
+    console:
+      enabled: true
+  profiles:
+    active: test
+mybatis:
+  mapper-locations: classpath:mapper/*.xml
+  configuration:
+    map-underscore-to-camel-case: true
+  type-handlers-package: com.ticketpark.configuration.mybatis.typeHandler
+logging:
+  level:
+    com:
+      ticketpark:
+        mybatis: trace
+retry:
+  optimisticLock:
+    count : 5
+

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -7,8 +7,8 @@ CREATE TABLE `member` (
                           `password`	        varchar(100)  NOT NULL,
                           `email`     	    varchar(100)  NULL	COMMENT '이메일 주소',
                           `hp_no`	            varchar(100)  NULL	COMMENT '핸드폰 번호',
-                          `created_dt`	    timestamp	  NULL	DEFAULT NOW()	COMMENT '회원 생성일시',
-                          `updated_dt`	    timestamp	  NULL	COMMENT '회원 수정일시',
+                          `created_dt`	    timestamp(9)	  NULL	DEFAULT NOW()	COMMENT '회원 생성일시',
+                          `updated_dt`	    timestamp(9)	  NULL	COMMENT '회원 수정일시',
                           `use_yn`	        char(1)	      NULL DEFAULT 'Y'	COMMENT '회원 삭제 구분'
 );
 
@@ -20,8 +20,8 @@ CREATE TABLE `performance` (
                                `name`	            varchar(500)  NULL	COMMENT '공연 이름',
                                `place`	            varchar(500)  NULL    COMMENT '공연 장소',
                                `start_dt`	        timestamp	  NOT NULL    COMMENT '공연 시작 일시',
-                               `end_dt`	        timestamp	  NOT NULL    COMMENT '공연 종료 일시',
-                               `created_at`	    timestamp	  NULL	DEFAULT NOW()	COMMENT '공연정보 생성일시'
+                               `end_dt`	        timestamp(9)	  NOT NULL    COMMENT '공연 종료 일시',
+                               `created_at`	    timestamp(9)	  NULL	DEFAULT NOW()	COMMENT '공연정보 생성일시'
 );
 
 -- 공연자
@@ -29,17 +29,17 @@ DROP TABLE IF EXISTS `performer`;
 CREATE TABLE `performer` (
                              `performer_id`	    bigint	      NOT NULL AUTO_INCREMENT PRIMARY KEY	COMMENT '공연자 ID',
                              `name`	            varchar(300)  NOT NULL	COMMENT '공연자명',
-                             `performance_id`    bigint        NOT NULL	COMMENT '공연 ID'
+                             `performance_id`   bigint        NOT NULL	COMMENT '공연 ID'
 );
 
 -- 티켓 정보
 DROP TABLE IF EXISTS `ticket`;
 CREATE TABLE `ticket` (
                           `ticket_id`	        bigint	      NOT NULL AUTO_INCREMENT PRIMARY KEY	COMMENT '티켓 ID',
-                          `start_dt`	        timestamp	  NOT NULL	COMMENT '티켓 예매시작시간',
-                          `end_dt`	        timestamp	  NOT NULL	COMMENT '티켓 예매종료시간',
-                          `created_dt`	    timestamp     NULL DEFAULT NOW() COMMENT '티켓 생성일시',
-                          `performance_id`	bigint	      NOT NULL	COMMENT '공연 ID'
+                          `start_dt`	        timestamp(9)	  NOT NULL	COMMENT '티켓 예매시작시간',
+                          `end_dt`	            timestamp(9)	  NOT NULL	COMMENT '티켓 예매종료시간',
+                          `created_dt`	        timestamp(9)     NULL DEFAULT NOW() COMMENT '티켓 생성일시',
+                          `performance_id`	    bigint	      NOT NULL	COMMENT '공연 ID'
 );
 
 -- 티켓 등급
@@ -50,7 +50,8 @@ CREATE TABLE `ticket_grade` (
                                 `grade_name`	    varchar(20)	  NOT NULL	COMMENT '티켓 등급 명칭',
                                 `seat_count`        mediumint     NOT NULL	COMMENT '티켓 등급별 좌석 수',
                                 `price`             decimal(18,6) NOT NULL  COMMENT '티켓 가격',
-                                `created_dt`	    timestamp     NULL DEFAULT NOW() COMMENT '티켓 생성일시',
+                                `version`           int           DEFAULT 0 COMMENT '버전',
+                                `created_dt`	    timestamp(9)  NULL DEFAULT NOW() COMMENT '티켓 생성일시',
                                 `ticket_id`	        bigint	      NOT NULL	COMMENT '티켓 ID'
 );
 
@@ -62,5 +63,5 @@ CREATE TABLE `ticket_order` (
                                 `performance_id`    bigint        NOT NULL    COMMENT '공연 ID',
                                 `ticket_grade_id`   bigint        NOT NULL    COMMENT '티켓 등급 ID',
                                 `seat_info`         varchar(50)   NOT NULL    COMMENT '좌석정보',
-                                `created_dt`	    timestamp     NULL DEFAULT NOW() COMMENT '티켓 생성일시'
+                                `created_dt`	    timestamp(9)  NULL DEFAULT NOW() COMMENT '티켓 생성일시'
 );


### PR DESCRIPTION
#  티켓 예매 다양한 락 기법 적용

## 변경 사항
- 테스트 실행 후 테스트 데이터 제거를 위한 TestDataCleaner 생성 
- 티켓 예매에 비관적, 낙관적, 네임드 락 적용하여 동시성 이슈 해결
- 다양한 락 전략 제공 위해서 인터페이스를 통한 DI 적용
  - 다이어그램 참고
 ![도식도-예매 구현체 drawio](https://github.com/user-attachments/assets/2f892463-4980-40da-81ee-6e286856452d)

## 예매 도식도
예매는 아래 3단계로 실행된다.
1) 선택한 좌석 등급의 좌석 수를 조회하여 좌석 수가 1이상인지 확인
2) 선택한 좌석 등급, 좌석 정보(ex1층 A열1번 자리)가 예매됐는지 확인
3) 선택한 좌석 등급의 좌석 수의 티켓 1장 감소, 예매정보 저장

![도식도-예매 전체 도식도 drawio](https://github.com/user-attachments/assets/7be37e42-cf67-4916-9f12-0fef8765f04c)
 
## 비관적 락
- 선택한 좌석 등급의 좌석 수 조회 쿼리에 락 적용(ticket_grade 테이블의 1 row)
- 선택한 좌석 등급, 좌석 정보 조회 쿼리에 락 적용(ticket_order 테이블의 1 row)
- ticket_grade, ticket_order 테이블 각각 1 row에 락을 걸고 티켓 등급 update, 예매 정보 insert하도록 구현

## 낙관적 락
- 선택한 좌석 등급의 티켓 매수 감소 시 낙관적 락 적용
- 선택한 좌석 등급의 버전 정보를 조회 후, 조회한 버전 정보로 조건을 걸어서 티켓 장수를 감소시킨다
- update된 row가 없다면 낙관적 락 exception 발생시켜서 티켓 예매 재처리 시도한다.
  - 재처리의 경우 AOP로 구현
  - 낙관적 락 실패 시 재처리 횟수는 application.yml에서 설정하도록 변경
```
retry:
  optimisticLock:
    count : 5
``` 
- 예매 가능한 좌석 수 체크하는 로직이 두 번 들어감
**1. 예매 가능 좌석 수 체크**
   2. 해당 좌석 예매 됐는지 확인
**3. 예매 가능 좌석 수 체크**
        해당 좌석 등급의 티켓 수 감소
        예매 정보 저장  
  - 이유 
`낙관적 락 멀티스레드 환경`에서 실행 시, `낙관적 락 실패 시 실행되는 예매 retry`로 인해서
첫번째 예매 좌석 수 체크에서는 남아있는 좌석이 존재하지만
세번째 예매 가능 좌석 수 체크에서는 좌석이 존재하지 않는 경우가 있어서
두 번의 좌석 수 체크 로직이 들어갔습니다.

- 낙관적 락 도식도
![도식도-낙관적 락 drawio (1)](https://github.com/user-attachments/assets/efa6506a-dd8c-4488-973f-447c2995542f)

## 네임드락
maria db의 네임드 락 이용
락 획득 - 예매 로직 실행 - 락 해제로 실행됩니다
1. 락 획득
2. 예매 가능 좌석 수 체크
3. 해당 좌석 예매 됐는지 확인
4. 해당 좌석 등급의 티켓 수 감소
   예매 정보 저장
5. 락 해제